### PR TITLE
Make imported grapphics read-only

### DIFF
--- a/usability/clipboard_dragdrop.js
+++ b/usability/clipboard_dragdrop.js
@@ -28,6 +28,7 @@ window.addEventListener('paste', function(event){
                     var str = '<img src="' + evt.target.result + '">';
                     new_cell.set_text(str);
                     new_cell.rendered = false;
+                    new_cell.read_only = true;
                     new_cell.render();
                     event.preventDefault();
                     return;


### PR DESCRIPTION
Set markdown cells to read-only to prevet going into edit mode with imported graphics.
