### PR TITLE
Use builtin function for print preview

### DIFF
--- a/publishing/printviewmenu_button.js
+++ b/publishing/printviewmenu_button.js
@@ -1,0 +1,21 @@
+//----------------------------------------------------------------------------
+//  Copyright (C) 2012  The IPython Development Team
+//
+//  Distributed under the terms of the BSD License.  The full license is in
+//  the file COPYING, distributed as part of this software.
+//----------------------------------------------------------------------------
+
+// add toolbar button calling File->Print Preview menu
+
+"use strict";
+  
+IPython.toolbar.add_buttons_group([
+    {
+        id : 'doPrintView',
+        label : 'Create static print view',
+        icon : 'icon-print',
+        callback : function(){$('#print_preview').click();}
+    }
+]);
+
+


### PR DESCRIPTION
IPython now provides a print preview in the File menu. Make the toolbar button use this instead of calling nbconvert manually.
