### PR TITLE
Add extension allowing to hide codecells

### DIFF
--- a/usability/toggle_codecells.js
+++ b/usability/toggle_codecells.js
@@ -34,4 +34,4 @@ var toggle_codecells_extension = (function() {
                 }
           ]);
       
-})(); 
+})();


### PR DESCRIPTION
As discussed in IPython-dev list

Clicking on toolbar symbol, all codecells can be hidden or shown again.
