### PR TITLE
updated custom.example.js includes all extensions in the repo

### DIFF
--- a/custom.example.js
+++ b/custom.example.js
@@ -15,10 +15,7 @@ $([IPython.events]).on('app_initialized.NotebookApp', function(){
      *  first argument of require is a **list** that can contains several modules if needed.
      **/
 
-    // require(['custom/noscroll']);
-    // require(['custom/clean_start'])
-    // require(['custom/toggle_all_line_number'])
-    // require(['custom/gist_it']);
+    // require(['custom/foo/bar'])
 
     /**
      *  Link to entrypoint if extension is a folder.
@@ -27,28 +24,30 @@ $([IPython.events]).on('app_initialized.NotebookApp', function(){
      *  action with the module if needed
      **/
 
-    // require(['custom/slidemode/main'],function(slidemode){
+    // require(['custom/foobar/main'],function(slidemode){
     //     // do stuff
     // })
-
-    // require(['custom/zenmode/main'],function(zenmode){
-    //
-    //   // You can use other images as a background, just check the
-    //   // zenmode/images folder or put there your own background...
-    //   // Don't forget to modify properly the the line below:
-    //
-    //   zenmode.background('images/back12.jpg');
-    //
-    //   // or if you want an IPython logo you can use:
-    //
-    //   zenmode.background('images/ipynblogo1.png');
-    //
-    //   console.log('Zenmode extension loaded correctly')
-    //
-    // })
+    
+    // zenmode example
+    /* require(['custom/styling/zenmode/main'],function(zenmode){
+     *
+     *   // You can use other images as a background, just check the
+     *   // zenmode/images folder or put there your own background...
+     *   // Don't forget to modify properly the the line below:
+     *
+     *   zenmode.background('images/back12.jpg');
+     *
+     *   // or if you want an IPython logo you can use:
+     *
+     *   zenmode.background('images/ipynblogo1.png');
+     *
+     *   console.log('Zenmode extension loaded correctly')
+     *
+     * })
+     */
 
     // software carpentry tags example.
-    /*  require(['custom/swc/main'],function(m){
+    /*  require(['custom/testing/swc/main'],function(m){
      *
      *       // param1 : Name of the preset in the dropdown selector
      *       // param2 : namespace to use in metadata
@@ -59,5 +58,61 @@ $([IPython.events]).on('app_initialized.NotebookApp', function(){
      *       console.log('Sofware carpentry tags extension loaded corectly')
      *  })
      */
+     
+    /*
+     * all exentensions from IPython-notebook-extensions, uncomment to activate
+     */
+     
+//    require(['custom/hierarchical_collapse'])
+    
+    // PUBLISHING
+//    require(['custom/publishing/nbviewer_theme/main'])
+//    require(['custom/publishing/gist_it'])
+//    require(['custom/publishing/nbconvert_button'])
+//    require(['custom/publishing/printview_button'])
+//    require(['custom/publishing/printviewmenu_button'])
+    
+    // SLIDEMODE
+//    require(['custom/slidemode/main'])
+    
+    // STYLING
+//    require(['custom/styling/css_selector/main'])
+//    require(['custom/styling/zenmode/main'],function(zenmode){
+//        zenmode.background('images/back12.jpg');
+//        console.log('Zenmode extension loaded correctly')
+//    })
+    
+    // TESTING
+//    require(['custom/testing/history/history'])
+//    require(['custom/testing/swc/main'],function(m){
+//        m.new_tag_set('Software Carpentry Tags', 'swc' ,['instructor','learner','exercise'])
+//        console.log('Sofware carpentry tags extension loaded corectly')
+//    })
+//    require(['custom/testing/cellstate'])
+    
+    // USABILITY
+//    require(['custom/usability/aspell/ipy-aspell']) // external python depency: python-aspell
+//    require(['custom/usability/codefolding/codefolding'])
+//    require(['custom/usability/dragdrop/drag-and-drop'])
+//    require(['custom/usability/help_panel/help_panel'])
+//    require(['custom/usability/init_cell/main'])
+//    require(['custom/usability/runtools/runtools'])
+//    require(['custom/usability/autosavetime'])
+//    require(['custom/usability/autoscroll'])
+//    require(['custom/usability/breakpoints'])
+//    require(['custom/usability/chrome_clipboard'])
+//    require(['custom/usability/clean_start'])
+//    require(['custom/usability/comment-uncomment'])
+//    require(['custom/usability/hide_input'])
+//    require(['custom/usability/hide_input_all'])
+//    require(['custom/usability/linenumbers'])
+//    require(['custom/usability/navigation-hotkeys'])
+//    require(['custom/usability/no_exec_dunder'])
+//    require(['custom/usability/noscroll'])
+//    require(['custom/usability/read-only'])
+//    require(['custom/usability/search'])
+//    require(['custom/usability/shift-tab'])
+//    require(['custom/usability/split-combine'])
+//    require(['custom/usability/toggle_all_line_number'])
 
 });


### PR DESCRIPTION
I would like to propose to include all currently listed notebook extensions in the repository in the custom.examle.js file so that users can more easily activate/de-activate them.

The first section of the file are the examples that where listed previously. They are followed with all extensions that are currently in the repository.
