### PR TITLE
Only activate drag&drop in command mode

### DIFF
--- a/usability/dragdrop/drag-and-drop.js
+++ b/usability/dragdrop/drag-and-drop.js
@@ -44,6 +44,7 @@ drag_and_drop = function() {
     
     /* allow dropping an image in notebook */
     window.addEventListener('drop', function(event){
+    if (IPython.notebook.mode === "edit") return;
 //    console.log("drop event x:",event);
         var cell = IPython.notebook.get_selected_cell();
         event.preventDefault();


### PR DESCRIPTION
The Drag&Drop should only work when in command mode, in edit mode,
handling by CodeMirror is fine.
