### PR TITLE
Make custom.example.js run in IPython 2.x and 3.x

### DIFF
--- a/custom.example.js
+++ b/custom.example.js
@@ -10,7 +10,7 @@ require(["base/js/events"], function (events) {
     } else {
         var ev = $([IPython.events]);
     }
-    ev.on("notebook_loaded.Notebook", function () {
+    ev.on("app_initialized.NotebookApp", function () {
     /*
      * all exentensions from IPython-notebook-extensions, uncomment to activate
      */


### PR DESCRIPTION
The last update of `custom.example.js` broke backward compatibility.

Is there a better way than to test for the IPython version ?
