### PR TITLE
Make sure notebook is loaded

### DIFF
--- a/usability/comment-uncomment.js
+++ b/usability/comment-uncomment.js
@@ -54,6 +54,10 @@ var comment_uncomment_extension = (function() {
      *
      */
     initExtension = function () {
+        if (!IPython.notebook) {
+            $([IPython.events]).on("app_initialized.NotebookApp", initExtension);
+            return;
+        }
         var cells = IPython.notebook.get_cells();
         for(var i in cells){
             registerKey(cells[i], commentKey);


### PR DESCRIPTION
Otherwise the extension crashes (i'm using require to load the extension from custom.js, like so:

require(["nbextensions/comment-uncomment"], function (gist_extension) {
    console.log('comment-uncomment extension loaded');
});

I just copied this section over from gist.js.
