### PR TITLE
Use keyboard_manager instead of hack for 'indentLess' hotkey

### DIFF
--- a/usability/shift-tab.js
+++ b/usability/shift-tab.js
@@ -6,7 +6,6 @@ var add_edit_shortcuts = {
             help    : 'indent less',
             help_index : 'eb',
             handler : function (event) {
-                console.log("shift-tab")
                 var cell = IPython.notebook.get_selected_cell();
                 cell.code_mirror.execCommand('indentLess')
                 return false;


### PR DESCRIPTION
Old extension doesn't work anymore. Use offical `keyboard_manager` instead of intercepting keyboard events in codemirror.
