### PR TITLE
Replace extension by a call to keyboard_manager

### DIFF
--- a/usability/comment-uncomment.js
+++ b/usability/comment-uncomment.js
@@ -1,64 +1,16 @@
-// add hotkey to comment/uncomment complete lines in codecells
-"using strict";
+// add new hotkey to toggle comments
 
-var comment_uncomment_extension = (function() {
-    var commentKey = { "Alt-C" : function(cm){toggleComments(cm)} };
-
-    function toggleComments(cm) { 
-        var from = cm.getCursor("start"), to = cm.getCursor("end");
-        cm.uncomment(from, to) || cm.lineComment(from, to);
-    };
-
-    /**
-     * Concatenate associative array objects
-     *
-     * Source: http://stackoverflow.com/questions/2454295/javascript-concatenate-properties-from-multiple-objects-associative-array
-     */
-    function collect() {
-    var ret = {};
-    var len = arguments.length;
-    for (var i=0; i<len; i++) {
-        for (p in arguments[i]) {
-            if (arguments[i].hasOwnProperty(p)) {
-                ret[p] = arguments[i][p];
+"use strict";
+var add_edit_shortcuts = {
+        'Alt-c' : {
+            help    : 'Toggle comments',
+            help_index : 'eb',
+            handler : function (event) {
+                var cm=IPython.notebook.get_selected_cell().code_mirror
+                var from = cm.getCursor("start"), to = cm.getCursor("end");
+                cm.uncomment(from, to) || cm.lineComment(from, to);
+                return false;
             }
-        }
-    }
-    return ret;
-}
-
-    /**
-     * Register extraKeys in codemirror cells
-     *
-     */
-    registerKey = function (cell, keyfunc) {
-        if ((cell instanceof IPython.CodeCell)) {
-            var keys = cell.code_mirror.getOption('extraKeys');
-            cell.code_mirror.setOption('extraKeys', collect(keys, keyfunc ));  
-        }
-    }
-    
-    /**
-     * Register key for newly created cells
-     *
-     * @param {Object} event
-     * @param {Object} nbcell notebook cell
-     */
-    createCell = function (event,nbcell,nbindex) {
-        var cell = nbcell.cell;
-        registerKey(cell, commentKey);
-    };
-
-    /**
-     * Initialize extension by registering hotkey for all codecells
-     *
-     */
-    initExtension = function () {
-        var cells = IPython.notebook.get_cells();
-        for(var i in cells){
-            registerKey(cells[i], commentKey);
-        }
-    $([IPython.events]).on('create.Cell',createCell);
-    }
-    require(['/static/components/codemirror/addon/comment/comment.js'],initExtension); 
-})();
+        },
+};
+IPython.keyboard_manager.edit_shortcuts.add_shortcuts(add_edit_shortcuts);


### PR DESCRIPTION
Update extension for IPython 3.x master.
Fixes https://github.com/ipython-contrib/IPython-notebook-extensions/issues/146
