### PR TITLE
Fix runtools for 2.x and use relative CSS import

### DIFF
--- a/usability/runtools/runtools.js
+++ b/usability/runtools/runtools.js
@@ -235,9 +235,6 @@ define([
     $([IPython.events]).on('create.Cell',create_cell);
     load_css('./runtools.css');
 
-    return {
-        load_ipython_extension : load_ipython_extension,
-        }
 });
 
 


### PR DESCRIPTION
Fixes https://github.com/ipython-contrib/IPython-notebook-extensions/issues/156
