### PR TITLE
Fix imagetransfer

### DIFF
--- a/usability/chrome_clipboard.js
+++ b/usability/chrome_clipboard.js
@@ -4,7 +4,7 @@
 define([
     'base/js/namespace',
     'jquery',
-    "base/js/events"
+    "base/js/events",
 ], function(IPython, $, events) {
     "use strict";
     if (window.chrome == undefined) return;
@@ -29,8 +29,11 @@ define([
         if (name == '') {
             name = uniqueid() + '.' + msg.match(/data:image\/(\S+);/)[1];
             }
-        var url = '//' + location.host + '/api/contents/' + path + '/' + name;
+        var path = path.substring(0, path.lastIndexOf('/')) + '/';
+        if (path === '/') path = '';
+        var url = '//' + location.host + '/api/contents/' + path + name;
         var img = msg.replace(/(^\S+,)/, ''); // strip header
+        var data = {'name': name, 'format':'base64', 'content': img, 'type': 'file'}
         var settings = {
             processData : false,
             cache : false,
@@ -46,10 +49,10 @@ define([
                 new_cell.execute();
                 //new_cell.select();
                 },
-            error : function() {console.log('Failed to send to server:',name); }
+            error : function() {console.log('Failed to send to server:',name); },
         };
         $.ajax(url, settings);
-    };
+    }        
     /* 
      * override clipboard 'paste' and insert new cell from json data in clipboard
      */
@@ -62,10 +65,10 @@ define([
                 //console.log("items:", items[i].type);
                 if (items[i].type == 'notebook-cell/json') {
                     /* json data adds a new notebook cell */
-                    var data = event.clipboardData.getData('notebook-cell/json').split("\n").filter(Boolean);
+                    var data = event.clipboardData.getData('notebook-cell/json').split("\n").filter(Boolean)
                     for (var i=0 ; i < data.length; i++) {
-                        var ix = data.length - 1 - i;
-                        var new_cell_data = JSON.parse(data[ix]);
+                        var ix = data.length - 1 - i
+                        var new_cell_data = JSON.parse(data[ix])
                         var new_cell = IPython.notebook.insert_cell_below(new_cell_data.cell_type);
                         new_cell.fromJSON(new_cell_data);
                         }
@@ -88,9 +91,9 @@ define([
      * override clipboard 'copy' and copy current cell as json and text to clipboard
      */
     window.addEventListener('copy', function(event){
-        var ncells = IPython.notebook.ncells();
-        var cells = IPython.notebook.get_cells();
-        var cell_indices = [];
+        var ncells = IPython.notebook.ncells()
+        var cells = IPython.notebook.get_cells()
+        var cell_indices = []
         for ( var i=0; i < ncells ; i++) {
             if (cells[i].metadata.selected === true) {
                 cell_indices.push(i)
@@ -105,12 +108,12 @@ define([
             var sel = window.getSelection();
             if (sel.type == "Range") return; /* default: copy marked text */
             event.preventDefault();
-            var json = "";
-            var text = "";
-            for (i in cell_indices) {
-                cell = cells[cell_indices[i]];
-                var j = _cell.toJSON();
-                json += JSON.stringify(j) + '\n';
+            var json = ""
+            var text = ""
+            for (var i in cell_indices) {
+                var cell = cells[cell_indices[i]]
+                var j = cell.toJSON();
+                json += JSON.stringify(j) + '\n'
                 text += cell.code_mirror.getValue() + '\n'
             }
             /* copy cell as json and cell contents as text */
@@ -123,9 +126,9 @@ define([
      * override clipboard 'cut' and copy current cell as json and text to clipboard
      */
     window.addEventListener('cut', function(event){
-                var ncells = IPython.notebook.ncells();
-        var cells = IPython.notebook.get_cells();
-        var cell_indices = [];
+                var ncells = IPython.notebook.ncells()
+        var cells = IPython.notebook.get_cells()
+        var cell_indices = []
         for ( var i=0; i < ncells ; i++) {
             if (cells[i].metadata.selected === true) {
                 cell_indices.push(i)
@@ -138,22 +141,21 @@ define([
         var cell = IPython.notebook.get_selected_cell();
         if (cell.mode == "command") { 
             var sel = window.getSelection();
-            if (sel.type == "Range")
-                return; /* default: copy marked text */
+            if (sel.type == "Range") return; /* default: copy marked text */
             event.preventDefault();
-            var json = "";
-            var text = "";
-            for (i in cell_indices) {
-                cell = cells[cell_indices[i]];
+            var json = ""
+            var text = ""
+            for (var i in cell_indices) {
+                var cell = cells[cell_indices[i]]
                 var j = cell.toJSON();
-                json += JSON.stringify(j) + '\n';
-                text += cell.code_mirror.getValue() + '\n';
+                json += JSON.stringify(j) + '\n'
+                text += cell.code_mirror.getValue() + '\n'
                 IPython.notebook.delete_cell(IPython.notebook.find_cell_index(cell));
             }
             /* copy cell as json and cell contents as text */
             event.clipboardData.setData('notebook-cell/json',json);        
             event.clipboardData.setData("Text", text);
         }
-    })
+    });
 });
 

--- a/usability/dragdrop/drag-and-drop.js
+++ b/usability/dragdrop/drag-and-drop.js
@@ -32,6 +32,7 @@ define([
             if (path === '/') path = '';
             var url = '//' + location.host + '/api/contents/' + path + name;
             var img = msg.replace(/(^\S+,)/, ''); // strip header
+            //console.log("send_to_server:", url, img);
             var data = {'name': name, 'format':'base64', 'content': img, 'type': 'file'};
             var settings = {
                 processData : false,


### PR DESCRIPTION
- chrome_clipboard and drag-and-drop extensions now use '//' instead of 'http://' to allow https
- cleanup
- update path variable after changes in master

Fixes https://github.com/ipython-contrib/IPython-notebook-extensions/issues/157
