### PR TITLE
Ci fixes

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -40,7 +40,7 @@ environment:
       PYTHON_VERSION: '3.4'
       PYTHON_ARCH: '32'
 
-    - TOXENV: 'py35-notebook,codecov'
+    - TOXENV: 'py35-notebook'
       TOXPYTHON: C:\Python35\python.exe
       PYTHON_HOME: C:\Python35
       PYTHON_VERSION: '3.5'
@@ -68,7 +68,7 @@ test_script:
   - '%PYTHON_HOME%\Scripts\tox -e %TOXENV%'
 
 on_success:
-  - '%PYTHON_HOME%\Scripts\tox -e codecov'
+  - cmd: '%PYTHON_HOME%\Scripts\tox -e codecov || (echo "codecov failed :(" && cmd /c "exit /b 0")'
 on_failure:
   - ps: $($env:COVERALLS_REPO_TOKEN = '')
   - ps: dir "env:"

--- a/setup.py
+++ b/setup.py
@@ -47,7 +47,7 @@ encounter any problems.
                       'tarball/0.1.0'),
         keywords=['IPython', 'Jupyter', 'notebook'],
         license='BSD',
-        platform=['Any'],
+        platforms=['Any'],
         packages=find_packages('src'),
         package_dir={'': 'src'},
         include_package_data=True,

--- a/tox.ini
+++ b/tox.ini
@@ -24,7 +24,7 @@ setenv =
 passenv = *
 usedevelop = false
 deps =
-    coverage
+    coverage<4.2
     mock
     nose
     notebook40: notebook>=4.0,<4.1
@@ -76,7 +76,9 @@ commands =
 
 [testenv:coveralls]
 skip_install = true
-deps = coveralls
+deps =
+    coverage<4.2
+    coveralls
 commands =
     coverage combine
     coverage report
@@ -85,6 +87,7 @@ commands =
 [testenv:codecov]
 skip_install = true
 deps =
+    coverage<4.2
     codecov
 commands =
     coverage combine
@@ -97,7 +100,7 @@ skip_install = true
 whitelist_externals = bash
 deps =
     appveyor-artifacts
-    coverage
+    coverage<4.2
     coveralls
 commands =
     appveyor-artifacts --owner-name=jcb91 --repo-name=ipython-notebook-extensions-ynb9f --mangle-coverage download
@@ -110,7 +113,7 @@ commands =
 
 [testenv:report]
 skip_install = true
-deps = coverage
+deps = coverage<4.2
 commands =
     coverage combine
     coverage report
@@ -118,7 +121,7 @@ commands =
 
 [testenv:clean]
 skip_install = true
-deps = coverage
+deps = coverage<4.2
 commands = coverage erase
 
 [testenv:bump]


### PR DESCRIPTION
 * fix typo'd setuptools kwarg `platform` --> `platforms`
 * fix appveyor toxenvs
 * attempt to get appveyor to pass even if codecov fails
 * temporarily pin coverage to version < 4.2 (see https://bitbucket.org/ned/coveragepy/issues/511)