### PR TITLE
Update check for html output

### DIFF
--- a/src/jupyter_contrib_nbextensions/nbconvert_support/post_embedhtml.py
+++ b/src/jupyter_contrib_nbextensions/nbconvert_support/post_embedhtml.py
@@ -47,7 +47,7 @@ class EmbedPostProcessor(PostProcessorBase):
         return img
 
     def postprocess(self, input):
-        if self.config.NbConvertApp.export_format == "html":
+        if self.config.NbConvertApp.export_format == "html" and self.config.option == "embed":
             regex = re.compile('<img\s+src="(\S+)"\s*(\S*)\s*/>')
             ext = input.split('.')[-1]
             output = input[0:-(len(ext) + 1)] + '-embedded.' + ext

--- a/src/jupyter_contrib_nbextensions/nbconvert_support/post_embedhtml.py
+++ b/src/jupyter_contrib_nbextensions/nbconvert_support/post_embedhtml.py
@@ -47,7 +47,7 @@ class EmbedPostProcessor(PostProcessorBase):
         return img
 
     def postprocess(self, input):
-        if self.config.export_format == "html":
+        if self.config.NbConvertApp.export_format == "html":
             regex = re.compile('<img\s+src="(\S+)"\s*(\S*)\s*/>')
             ext = input.split('.')[-1]
             output = input[0:-(len(ext) + 1)] + '-embedded.' + ext


### PR DESCRIPTION
Change `export_format` test. Unfortunately, now adding `-to html` to the nbconvert call is mandatory.
To enable embedding use:
```
nbconvert --to html --option='embed' notebook.ipynb
```