### PR TITLE
make file ASCII compatible

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,4 +1,4 @@
-# explicit includes
+# explicit includes
 include COPYING.rst
 include README.md
 include tox.ini


### PR DESCRIPTION
Currently the MANIFEST.in contains a character that is incompatible with ASCII encoding, which makes pip3 unable to install the library because Python3 uses ASCII encoding. The pull request changes the character to a normal ASCII compatible space. 