### PR TITLE
Fix limit_output extension

### DIFF
--- a/src/jupyter_contrib_nbextensions/nbextensions/limit_output/limit-output.yaml
+++ b/src/jupyter_contrib_nbextensions/nbextensions/limit_output/limit-output.yaml
@@ -15,4 +15,4 @@ Parameters:
 - name: limit_output_message
   description: Message to append when output is limited
   input_type: text
-  default: '**OUTPUT MUTED**'
+  default: '<b>limit_output extension: Maximum message size exceeded</b>'

--- a/src/jupyter_contrib_nbextensions/nbextensions/limit_output/readme.md
+++ b/src/jupyter_contrib_nbextensions/nbextensions/limit_output/readme.md
@@ -1,4 +1,10 @@
-This extension limits the number of characters a codecell can output as text. This also allows to interrupt endless loops.
+Limit_output Extension
+======================
+
+Description
+-----------
+This extension limits the number of characters a codecell will output as text or HTML.
+This also allows to interrupt endless loops of print commands.
 
 [![Demo Video](http://img.youtube.com/vi/U26ujuPXf00/0.jpg)](https://youtu.be/U26ujuPXf00)
 
@@ -10,3 +16,12 @@ cm = ConfigManager().update('notebook', {'limit_output': 1000})
 ```
 
 or by using the [`jupyter_nbextensions_configurator`](https://github.com/Jupyter-contrib/jupyter_nbextensions_configurator)
+
+Internals
+---------
+
+Three types of messages are intercepted: `stream`, `execute_result`, `display_data`
+
+For `stream`- type messages, the text string length is limited to `limit_output` number of characters
+For other message types, `text/plain` and `text/html` content length is counted` and if either
+exceeds `limit_output` charaters, will be truncated.


### PR DESCRIPTION
* Make it work for more message types
* Truncate text and HTML messages
* Output truncation notice separately

Addresses https://github.com/ipython-contrib/jupyter_contrib_nbextensions/pull/721