### PR TITLE
default to system-wide install to avoid parameter conflicts

### DIFF
--- a/src/jupyter_contrib_nbextensions/application.py
+++ b/src/jupyter_contrib_nbextensions/application.py
@@ -85,7 +85,7 @@ class BaseContribNbextensionsInstallApp(BaseContribNbextensionsApp):
     nbextensions_dir = Unicode(
         '', config=True,
         help='Full path to nbextensions dir '
-        '(consider instead using sys_prefix, prefix or user)')
+        '(consider instead using system, sys_prefix, prefix or user option)')
 
     def parse_command_line(self, argv=None):
         """

--- a/src/jupyter_contrib_nbextensions/application.py
+++ b/src/jupyter_contrib_nbextensions/application.py
@@ -70,7 +70,7 @@ class BaseContribNbextensionsInstallApp(BaseContribNbextensionsApp):
         ),
     }
 
-    user = Bool(True, config=True, help='Whether to do a user install')
+    user = Bool(False, config=True, help='Whether to do a user install')
     sys_prefix = Bool(False, config=True,
                       help='Use the sys.prefix as the prefix')
 

--- a/src/jupyter_contrib_nbextensions/install.py
+++ b/src/jupyter_contrib_nbextensions/install.py
@@ -52,8 +52,8 @@ def toggle_install(install, user=False, sys_prefix=False, overwrite=False,
     if notebook_is_running():
         raise NotebookRunningError(
             'Cannot configure while the Jupyter notebook server is running')
-
-    user = False if sys_prefix else user
+    _check_conflicting_kwargs(user=user, sys_prefix=sys_prefix, prefix=prefix,
+                              nbextensions_dir=nbextensions_dir)
     config_dir = nbextensions._get_config_dir(user=user, sys_prefix=sys_prefix)
 
     verb = 'Installing' if install else 'Uninstalling'
@@ -144,6 +144,15 @@ def uninstall(user=False, sys_prefix=False, prefix=None, nbextensions_dir=None,
 # -----------------------------------------------------------------------------
 # Private API
 # -----------------------------------------------------------------------------
+
+
+def _check_conflicting_kwargs(**kwargs):
+    if sum(map(bool, kwargs.values())) > 1:
+        raise nbextensions.ArgumentConflict(
+            "Cannot specify more than one of {}.\nBut recieved {}".format(
+                ', '.join(kwargs.keys),
+                ', '.join(['{}={}'.format(k, v)
+                           for k, v in kwargs.items() if v])))
 
 
 def _set_managed_config(cm, config_basename, config, logger=None):


### PR DESCRIPTION
 * Make `user` default to `False`, as otherwise it conflicts with other custom install options like `nbextensions_dir` and `prefix`. This makes app default to system install.
 * alter tests to account for new default install
 * alter tests to check *all* potential installation directories, to ensure we don't place anything in a location we shouldn't touch
 * test app `--prefix=` cli arg