### PR TITLE
highlighter: fixed tooltips

### DIFF
--- a/src/jupyter_contrib_nbextensions/nbextensions/highlighter/highlighter.js
+++ b/src/jupyter_contrib_nbextensions/nbextensions/highlighter/highlighter.js
@@ -246,11 +246,7 @@ $("#higlighter_menu").css({
 $("#higlighter_menu")
     .on('click', function() {
         $("#submenu").toggle();
-        if ($("#menu-hgl").hasClass("fa-caret-right")) {
-            $("#menu-hgl").switchClass("fa-caret-right", "fa-caret-left")
-        } else {
-            $("#menu-hgl").switchClass("fa-caret-left", "fa-caret-right")
-        }
+        $("#menu-hgl").toogleClass("fa-caret-right", "fa-caret-left")
     })
     .attr('title', 'Highlight Selected Text');
 

--- a/src/jupyter_contrib_nbextensions/nbextensions/highlighter/highlighter.js
+++ b/src/jupyter_contrib_nbextensions/nbextensions/highlighter/highlighter.js
@@ -246,7 +246,7 @@ $("#higlighter_menu").css({
 $("#higlighter_menu")
     .on('click', function() {
         $("#submenu").toggle();
-        $("#menu-hgl").toogleClass("fa-caret-right", "fa-caret-left")
+        $("#menu-hgl").toggleClass("fa-caret-right", "fa-caret-left")
     })
     .attr('title', 'Highlight Selected Text');
 

--- a/src/jupyter_contrib_nbextensions/nbextensions/highlighter/highlighter.js
+++ b/src/jupyter_contrib_nbextensions/nbextensions/highlighter/highlighter.js
@@ -245,23 +245,15 @@ $("#higlighter_menu").css({
 
 $("#higlighter_menu")
     .on('click', function() {
-    $("#submenu").toggle();
-    if($("#menu-hgl").hasClass("fa-caret-right")){ 
-        $("#menu-hgl").switchClass("fa-caret-right","fa-caret-left") 
-    } 
-    else {
-        $("#menu-hgl").switchClass("fa-caret-left","fa-caret-right")
-    }
-    })
-.tooltip({
-        title: 'Highlight selected text',
-        placement: "bottom",     
-        trigger: "hover",
-        delay: {
-            show: 500,
-            hide: 50
+        $("#submenu").toggle();
+        if ($("#menu-hgl").hasClass("fa-caret-right")) {
+            $("#menu-hgl").switchClass("fa-caret-right", "fa-caret-left")
+        } else {
+            $("#menu-hgl").switchClass("fa-caret-left", "fa-caret-right")
         }
-    });
+    })
+    .attr('title', 'Highlight Selected Text');
+
 
 $("#b1")
     .on('click', function() {
@@ -303,15 +295,7 @@ $("#remove_highlights")
     .on('click', function() {
         removeHighlights()
     })
-    .tooltip({
-        title: 'Remove highlightings in selected cell',
-        placement:"bottom",
-        trigger: "hover",
-        delay: {
-            show: 500,
-            hide: 50
-        }
-    });
+    .attr('title', 'Remove highlightings in selected cell');
 
 
 //******************************* MAIN FUNCTION **************************

--- a/src/jupyter_contrib_nbextensions/nbextensions/highlighter/readme.md
+++ b/src/jupyter_contrib_nbextensions/nbextensions/highlighter/readme.md
@@ -1,4 +1,5 @@
-# Highlighter
+
+## The highlighter extension:
 
 - Firstable, the extension provides <span class="mark">several toolbar buttons</span> for highlighting a selected text _within a markdown cell_. Three different \`color schemes' are provided, which can be easily customized in the stylesheet `highlighter.css`. The last button enables to remove all highlightings in the current cell. 
 - This works both <span class="burk">when the cell is _rendered_ and when the cell is in edit mode</span>; 


### PR DESCRIPTION
Tooltips for highlighter buttons disappeared some times ago (probably for me after a Jupyter version upgrade). Don't really know what happened. The simple fix here restore them. 