### PR TITLE
code_prettify: Corrected insufficient re replacement that led to spurious `\n` for blank lines

### DIFF
--- a/src/jupyter_contrib_nbextensions/nbextensions/code_prettify/README.md
+++ b/src/jupyter_contrib_nbextensions/nbextensions/code_prettify/README.md
@@ -16,10 +16,11 @@ pip install yapf [--user]
 ```
 install.packages("formatR", repos = "http://cran.rstudio.com")
 ``` 
-- for ijavascript (*in the root of your user tree = ~*)
+- for ijavascript (*Under linux, in the root of your user tree = ~*)
 ```
 npm install js-beautify
 ``` 
+Under windows, you may then need to set the `NODE_PATH` environment variable: [From stackoverflow](http://stackoverflow.com/questions/9587665/nodejs-cannot-find-installed-module-on-windows) set it to %AppData%\npm\node_modules (Windows 7/8/10). To be done with it once and for all, add this as a System variable in the Advanced tab of the System Properties dialog.
 
 Then the extension provides
 

--- a/src/jupyter_contrib_nbextensions/nbextensions/code_prettify/code_prettify.js
+++ b/src/jupyter_contrib_nbextensions/nbextensions/code_prettify/code_prettify.js
@@ -73,7 +73,8 @@ define(function(require, exports, module) {
                 var reg = RegExp(quote + '[\\S\\s]*' + quote)
                 var ret = String(ret).match(reg)[0] // extract text between quotes
                 ret = ret.substr(1, ret.length - 2) //suppress quotes 
-                ret = ret.replace(/([^\\])\\n/g, "$1\n") // replace \n if not escaped
+                ret = ret.replace(/([^\\])\\n/g, "$1\n").replace(/([^\\])\\n/g, "$1\n") 
+                        // replace \n if not escaped (two times beacause of recovering subsequences)
                 .replace(/([^\\])\\\\\\n/g, "$1\\\n") // [continuation line] replace \ at eol (but no conversion)
                     .replace(/\\'/g, "'") // replace simple quotes
                     .replace(/\\\\/g, "\\") // unescape


### PR DESCRIPTION
This is for the Python prettifying part. 
Blank lines were incorrectly (of course) replaced by the `\n` string. 

In short I fell into a regex trap where I forgot that regex gobble matching characters., thus missed some matches.  The simple solution here solves this issue. 