### PR TITLE
toc2: fixed zero-size navigation menu

### DIFF
--- a/src/jupyter_contrib_nbextensions/nbextensions/toc2/README.md
+++ b/src/jupyter_contrib_nbextensions/nbextensions/toc2/README.md
@@ -39,10 +39,6 @@ or
 ```
 jupyter nbconvert FILE.ipynb --template toc2
 ```
-An exporter is also available. It is now possible to export to html with toc by 
-```
-jupyter nbconvert --to html_toc FILE.ipynb 
-```
 For the first template (toc), the files toc2.js and main.css (originally located in &lt;python site-packages&gt;/jupyter_contrib_nbextensions/nbextensions/toc2) must reside in the same directory as intended for the html file. In the second template, these files are linked to the ipython-contrib/jupyter_contrib_nbextensions github website. Export configuration (parameters) shall be edited directly in the template files (in templates directory &lt;python site-packages&gt;/jupyter_contrib_nbextensions/templates). An option "Save as HTML (with toc)" is also provided in the File menu and enable to directly convert the actual notebook. This option requires the IPython kernel and is not present with other kernels.
 
  
@@ -64,5 +60,4 @@ from https://gist.github.com/magican/5574556
 - @jfbercher february 21, 2016. Fixed some issues when resizing the toc window. Now avoid overflows, clip the text and add a scrollbar. 
 - @jfbercher february 22, 2016. Add current toc number to headings anchors. This enable to get unique anchors for recurring headings with the same text. An anchor with the original ID is still created and can be used (but toc uses the new ones!). It is also possible to directly add an html anchor within the heading text. This is taken into account when building toc links (see comments in code). 
 - @jfbercher april 29, 2016. Triggered by @cqcn1991, cf [discussion here](https://github.com/ipython-contrib/jupyter_contrib_nbextensions/issues/532),  add a sidebar option. The floating toc window can be dragged and docked as a left sidebar. The sidebar can be dragged out as a floating window. These different states are stored and restored when reloading the notebook. Add html export capability via templates toc.tpl and toc2.tpl (see above).
-- @jfbercher may 04, 2016. Added a "Save as HTML with toc" menu. Added a new "Navigate" menu with presents the contents of the toc. Changed default styling for links in tocs. 
-- @jfbercher july 28, 2016. A dedicated exporter was added.  It is now possible to export to html with toc by  `jupyter nbconvert --to html_toc FILE.ipynb`
+- - @jfbercher may 04, 2016. Added a "Save as HTML with toc" menu. Added a new "Navigate" menu with presents the contents of the toc. Changed default styling for links in tocs. 

--- a/src/jupyter_contrib_nbextensions/nbextensions/toc2/README.md
+++ b/src/jupyter_contrib_nbextensions/nbextensions/toc2/README.md
@@ -39,10 +39,14 @@ or
 ```
 jupyter nbconvert FILE.ipynb --template toc2
 ```
+An exporter is also available. It is now possible to export to html with toc by 
+```
+jupyter nbconvert --to html_toc FILE.ipynb 
+```
 For the first template (toc), the files toc2.js and main.css (originally located in &lt;python site-packages&gt;/jupyter_contrib_nbextensions/nbextensions/toc2) must reside in the same directory as intended for the html file. In the second template, these files are linked to the ipython-contrib/jupyter_contrib_nbextensions github website. Export configuration (parameters) shall be edited directly in the template files (in templates directory &lt;python site-packages&gt;/jupyter_contrib_nbextensions/templates). An option "Save as HTML (with toc)" is also provided in the File menu and enable to directly convert the actual notebook. This option requires the IPython kernel and is not present with other kernels.
 
  
-# Testing 
+## Testing 
 - At loading of the notebook, configuration and initial rendering of the table of contents were fired on the event "notebook_loaded.Notebook". It happens that the extension is sometimes loaded *after* this event. I now rely  on a direct rendering at load and on a combination of  "notebook_loaded.Notebook" and "kernel_ready.Kernel". 
 
 - This extension also includes a quick workaround as described in https://github.com/ipython-contrib/jupyter_contrib_nbextensions/issues/429
@@ -52,7 +56,7 @@ For the first template (toc), the files toc2.js and main.css (originally located
 - This extension was adapted by minrk https://github.com/minrk/ipython_extensions
 from https://gist.github.com/magican/5574556
 - Added to the ipython-contrib/jupyter_contrib_nbextensions repo by @JanSchulz
-- @junasch, automatic update on markdown rendering, 
+- @juhasch, automatic update on markdown rendering, 
 - @JanSchulz, enable maths in headers links
 - @jfbercher december 06, 2015 -- Big update: automatic numbering, toc cell, window dragging, configuration parameters
 - @jfbercher december 24, 2015 -- nested numbering in toc-window, following the fix by [@paulovn](https://github.com/minrk/ipython_extensions/pull/53) in @minrk's repo. December 30-31, updated config in toc2.yaml to enable choosing the initial visible state of toc_window via a checkbox ; and now resizable. 
@@ -60,4 +64,6 @@ from https://gist.github.com/magican/5574556
 - @jfbercher february 21, 2016. Fixed some issues when resizing the toc window. Now avoid overflows, clip the text and add a scrollbar. 
 - @jfbercher february 22, 2016. Add current toc number to headings anchors. This enable to get unique anchors for recurring headings with the same text. An anchor with the original ID is still created and can be used (but toc uses the new ones!). It is also possible to directly add an html anchor within the heading text. This is taken into account when building toc links (see comments in code). 
 - @jfbercher april 29, 2016. Triggered by @cqcn1991, cf [discussion here](https://github.com/ipython-contrib/jupyter_contrib_nbextensions/issues/532),  add a sidebar option. The floating toc window can be dragged and docked as a left sidebar. The sidebar can be dragged out as a floating window. These different states are stored and restored when reloading the notebook. Add html export capability via templates toc.tpl and toc2.tpl (see above).
-- - @jfbercher may 04, 2016. Added a "Save as HTML with toc" menu. Added a new "Navigate" menu with presents the contents of the toc. Changed default styling for links in tocs. 
+- @jfbercher may 04, 2016. Added a "Save as HTML with toc" menu. Added a new "Navigate" menu with presents the contents of the toc. Changed default styling for links in tocs. 
+- @jfbercher july 28, 2016. A dedicated exporter was added.  It is now possible to export to html with toc by  `jupyter nbconvert --to html_toc FILE.ipynb`
+- @jfbercher septemeber 21, 2016. Fixed empty size of navigation menu (if no resize had occur). Changed system/notebook configuration parameters storing, loading and merging.  

--- a/src/jupyter_contrib_nbextensions/nbextensions/toc2/toc2.yaml
+++ b/src/jupyter_contrib_nbextensions/nbextensions/toc2/toc2.yaml
@@ -6,31 +6,31 @@ Icon: icon.png
 Main: main.js
 Compatibility: 4.x
 Parameters:
-- name: number_sections
+- name: toc2.number_sections
   description: Automatically number notebook's sections
   input_type: checkbox
   default: true
-- name: threshold
+- name: toc2.threshold
   description: Maximum level of nested sections to display on the tables of contents
   input_type: number
   min: -1
   step: 1
   default: 4
-- name: toc_cell
+- name: toc2.toc_cell
   description: Add a Table of Contents cell at the top of the notebook
   input_type: checkbox
   default: false
-- name: toc_window_display
-  description: Display toc window at startup
+- name: toc2.toc_window_display
+  description: Display toc window/sidebar at startup
   input_type: checkbox
   default: false
-- name: sideBar
+- name: toc2.sideBar
   description: Display Table of Contents as a sidebar (otherwise as a floating window)
   input_type: checkbox
   default: true  
-- name: navigate_menu
+- name: toc2.navigate_menu
   description: Display Table of Contents as a navigation menu
   input_type: checkbox
-  default: false
+  default: true
   
 


### PR DESCRIPTION
- fixed issue with zero-length navigation menu 
The size of the resizable navigation menu is stored in notebook's metadata. The update is done automatically each time the resize event is sent. The size was not stored before any resize. At reload, the size was read as empty and the navigation menu was reduced to a zero size. 
The menu size is now stored just before saving the notebook, which solves his issue. 
- store toc parameters as an object in notebook.json (instead of messing the section with all that)
- changed loading and merging of toc parameters in system and notebook metadata. 

There is still a big cleanup to do in the code... 
