### PR TITLE
Add pointer to documentation at readthedocs

### DIFF
--- a/src/jupyter_contrib_nbextensions/install.py
+++ b/src/jupyter_contrib_nbextensions/install.py
@@ -75,6 +75,10 @@ def toggle_install(install, user=False, sys_prefix=False, overwrite=False,
         nbextensions.install_nbextension_python(
             jupyter_contrib_nbextensions.__name__,
             overwrite=overwrite, symlink=symlink, **kwargs)
+        # enable contrib_nbextensions_help_item (item in help menu)
+        nbextensions.enable_nbextension('notebook',
+                'contrib_nbextensions_help_item/main', 
+                user=user, sys_prefix=sys_prefix)
     else:
         nbextensions.uninstall_nbextension_python(
             jupyter_contrib_nbextensions.__name__, **kwargs)

--- a/src/jupyter_contrib_nbextensions/nbextensions/contrib_nbextensions_help_item/README.md
+++ b/src/jupyter_contrib_nbextensions/nbextensions/contrib_nbextensions_help_item/README.md
@@ -1,1 +1,4 @@
+Help menu entry
+===============
+
 The contrib_nbextensions_help_item is a tiny extension that just adds an item in the notebook's help menu, pointing to the jupyter_contrib_nbextensions at readthedocs.

--- a/src/jupyter_contrib_nbextensions/nbextensions/contrib_nbextensions_help_item/README.md
+++ b/src/jupyter_contrib_nbextensions/nbextensions/contrib_nbextensions_help_item/README.md
@@ -1,0 +1,1 @@
+The contrib_nbextensions_help_item is a tiny extension that just add an item in the notebook's help menu, pointing to the jupyter_contrib_nbextensions at readthedocs.

--- a/src/jupyter_contrib_nbextensions/nbextensions/contrib_nbextensions_help_item/README.md
+++ b/src/jupyter_contrib_nbextensions/nbextensions/contrib_nbextensions_help_item/README.md
@@ -1,1 +1,1 @@
-The contrib_nbextensions_help_item is a tiny extension that just add an item in the notebook's help menu, pointing to the jupyter_contrib_nbextensions at readthedocs.
+The contrib_nbextensions_help_item is a tiny extension that just adds an item in the notebook's help menu, pointing to the jupyter_contrib_nbextensions at readthedocs.

--- a/src/jupyter_contrib_nbextensions/nbextensions/contrib_nbextensions_help_item/contrib_nbextensions_help_item.yaml
+++ b/src/jupyter_contrib_nbextensions/nbextensions/contrib_nbextensions_help_item/contrib_nbextensions_help_item.yaml
@@ -1,6 +1,6 @@
 Type: Jupyter Notebook Extension
 Name: contrib_nbextensions_help_item 
-Description: The contrib_nbextensions_help_item is a tiny extension that just add an item in the notebook's help menu, pointing to the jupyter_contrib_nbextensions at readthedocs.  
+Description: The contrib_nbextensions_help_item is a tiny extension that just adds an item in the notebook's help menu, pointing to the jupyter_contrib_nbextensions at readthedocs.  
 Link: README.md
 Icon: icon.png
 Main: main.js

--- a/src/jupyter_contrib_nbextensions/nbextensions/contrib_nbextensions_help_item/contrib_nbextensions_help_item.yaml
+++ b/src/jupyter_contrib_nbextensions/nbextensions/contrib_nbextensions_help_item/contrib_nbextensions_help_item.yaml
@@ -1,0 +1,7 @@
+Type: Jupyter Notebook Extension
+Name: contrib_nbextensions_help_item 
+Description: The contrib_nbextensions_help_item is a tiny extension that just add an item in the notebook's help menu, pointing to the jupyter_contrib_nbextensions at readthedocs.  
+Link: README.md
+Icon: icon.png
+Main: main.js
+Compatibility: 4.x

--- a/src/jupyter_contrib_nbextensions/nbextensions/contrib_nbextensions_help_item/main.js
+++ b/src/jupyter_contrib_nbextensions/nbextensions/contrib_nbextensions_help_item/main.js
@@ -1,0 +1,35 @@
+// Small extension to add an help menu pointing 
+// to jupyter_contrib_nbextensions at readthedocs.
+
+define(['jquery', 'base/js/namespace'], function($, Jupyter) {
+    "use strict";
+
+    function add_help_menu_item() {
+
+        if ($('#jupyter_contrib_nbextensions_help').length > 0) {
+            return;
+        }
+        var menu_item = $('<li/>')
+            .append(
+                $('<a/>')
+                .html('Jupyter-contrib <br> nbextensions')
+                .attr('title', 'Jupyter_contrib_nbextensions documentation')
+                .attr('id', "jupyter_contrib_nbextensions_help")
+                .attr('href', 'http://jupyter-contrib-nbextensions.readthedocs.io/en/latest/')
+                .attr('target', "_blank")
+                .append(
+                    $('<i/>')
+                    .addClass('fa fa-external-link menu-icon pull-right')
+                ))
+        menu_item.insertBefore($($("#help_menu > .divider")[1]))
+    }
+
+
+    var load_ipython_extension = function() {
+        add_help_menu_item();
+    };
+
+    return {
+        load_ipython_extension: load_ipython_extension
+    };
+});


### PR DESCRIPTION
The contrib_nbextensions_help_item is a tiny extension that just adds an item in the notebook's help menu, pointing to the jupyter_contrib_nbextensions at readthedocs. This little  extension is automatically enabled during install. 
I didn't found a name that fits on a single line; suggestions welcome!

![jcnb_help_menu_item](https://cloud.githubusercontent.com/assets/7596356/18816311/15f83028-8347-11e6-9583-93ae69edd8c7.png)
