### PR TITLE
select_keymap: Fix bugs introduced in code cleanup

### DIFF
--- a/src/jupyter_contrib_nbextensions/nbextensions/select_keymap/main.js
+++ b/src/jupyter_contrib_nbextensions/nbextensions/select_keymap/main.js
@@ -118,7 +118,7 @@ define([
 
         function openDialog_keymap_wrapper(target, template, callback, options) {
             Jupyter.keyboard_manager.disable();
-            return target.call(_this, template, callback, options);
+            return target.call(this, template, callback, options);
         }
 
         CodeMirror.defineExtension("openDialog", _.wrap(_this.openDialog,

--- a/src/jupyter_contrib_nbextensions/nbextensions/select_keymap/main.js
+++ b/src/jupyter_contrib_nbextensions/nbextensions/select_keymap/main.js
@@ -232,7 +232,7 @@ define([
         ];
 
         available_keymaps.forEach(function(keymap) {
-            menu.push(`<li><a id="keymap-${keymap}" href="#" title="Toggle ${keymap} keybindings" onClick="switch_keymap("${keymap}")" style="text-transform: capitalize;">${keymap}</a></li>`);
+            menu.push(`<li><a id="keymap-${keymap}" href="#" title="Toggle ${keymap} keybindings" onClick="switch_keymap('${keymap}')" style="text-transform: capitalize;">${keymap}</a></li>`);
         });
 
         menu.push("</ul></li>");

--- a/src/jupyter_contrib_nbextensions/nbextensions/select_keymap/main.js
+++ b/src/jupyter_contrib_nbextensions/nbextensions/select_keymap/main.js
@@ -93,7 +93,12 @@ define([
                 },
                 command_shortcuts: {
                     "ctrl-n": "jupyter-notebook:select-next-cell",
-                    "ctrl-p": "jupyter-notebook:select-previous-cell"
+                    "ctrl-p": "jupyter-notebook:select-previous-cell",
+                    "Alt-X": "jupyter-notebook:show-command-palette"
+
+                },
+                edit_shortcuts: {
+                    "Alt-X": "jupyter-notebook:show-command-palette"
                 }
             },
             remove: {


### PR DESCRIPTION
In one of my commits I had standardized use of quotes, which introduced a bug in the `onClick` call. This fixes it.