### PR TITLE
[Freeze] Extend functionality to markdown cells

### DIFF
--- a/src/jupyter_contrib_nbextensions/nbextensions/freeze/main.js
+++ b/src/jupyter_contrib_nbextensions/nbextensions/freeze/main.js
@@ -1,142 +1,142 @@
 define([
-	'base/js/namespace',
-	'base/js/events',
-	'notebook/js/codecell',
-	'jquery'
+    'base/js/namespace',
+    'base/js/events',
+    'notebook/js/codecell',
+    'jquery'
 ], function (
-	Jupyter,
-	events,
-	codecell,
-	$
+    Jupyter,
+    events,
+    codecell,
+    $
 ){
-	'use strict';
-	
-	var CodeCell = codecell.CodeCell;
-	
-	function patch_CodeCell_execute () {
-		console.log('[Freeze] patching CodeCell.prototype.execute')	
-		var old_execute = CodeCell.prototype.execute;
-		
-		CodeCell.prototype.execute = function () {
-			if (this.metadata.run_control === undefined ||
-				!this.metadata.run_control.frozen
-			) {
-				old_execute.apply(this, arguments);
-			}
-		}
-	}
-	
-	function set_state(cell, state) { 
-		if (cell instanceof CodeCell) {
-			if (cell.metadata.run_control === undefined)
-				cell.metadata.run_control = {};
-			if (state === undefined)
-				state = 'normal';			
-			switch(state) {
-				case 'normal':
-					var new_run_control_values = {
-						read_only : false,
-						frozen : false
-					};
-					var bg = "";
-					break;
-				case 'read_only':
-					var new_run_control_values = {
-							read_only : true,
-							frozen : false
-					};
-					var bg = "#FFFEF0";
-					break;
-				case 'frozen':
-					var new_run_control_values = {
-						read_only : true,
-						frozen : true
-					};
-					var bg = "#f0feff";
-					break;
-			}
-			$.extend(cell.metadata.run_control, new_run_control_values);
-			cell.code_mirror.setOption('readOnly', cell.metadata.run_control.read_only);
-			var prompt = cell.element.find('div.input_area');
-			prompt.css("background-color", bg);
-		}
-	}
+    'use strict';
 
-	function set_state_selected (state) {
-		var cells = Jupyter.notebook.get_selected_cells();
-		for (var i = 0; i < cells.length; i++) {
-			set_state(cells[i], state)
-		}
-	}
-	
-	function make_normal_selected () {
-		set_state_selected('normal');
-	}
+    var CodeCell = codecell.CodeCell;
 
-	function make_read_only_selected () {
-		set_state_selected('read_only');
-	}
-	
-	function make_frozen_selected () {
-		set_state_selected('frozen');
-	}
-	
-	
-	function initialize_states () {
-		var cells = Jupyter.notebook.get_cells();
-		for (var i in cells) {
-			var cell = cells[i];
-			if (cell instanceof CodeCell) {
-				if (cell.metadata.run_control != undefined) {
-					if (cell.metadata.run_control.read_only) {
-						if (cell.metadata.run_control.frozen) {
-							set_state(cell, 'frozen')
-						} else {
-							set_state(cell, 'read_only')
-						}
-					} else {
-						set_state(cell, 'normal')
-					}
-				} else {
-					set_state(cell, 'normal');
-				}
-			}
-		}
-	}
-	
-	function load_extension () {
-		Jupyter.toolbar.add_buttons_group([
-			{
-				id : 'make_normal',
-				label : 'lift restrictions from selected cells',
-				icon : 'fa-unlock-alt',
-				callback : make_normal_selected
-			},
-			{
-				id : 'make_read_only',
-				label : 'make selected cells read-only',
-				icon: 'fa-lock',
-				callback : make_read_only_selected
-			},
-			{
-				id : 'freeze_cells',
-				label : 'freeze selected cells',
-				icon : 'fa-asterisk',
-				callback : make_frozen_selected
-			}
-		]);
-		
-		if (typeof Jupyter.notebook === "undefined") {
-			events.on("notebook_loaded.Notebook", initialize_states)
-		} else {
-			initialize_states();
-		}
-		
-		patch_CodeCell_execute();
-	}
-	
-	return {
-		load_jupyter_extension : load_extension,
-		load_ipython_extension : load_extension
-	}
+    function patch_CodeCell_execute () {
+        console.log('[Freeze] patching CodeCell.prototype.execute')
+        var old_execute = CodeCell.prototype.execute;
+
+        CodeCell.prototype.execute = function () {
+            if (this.metadata.run_control === undefined ||
+                !this.metadata.run_control.frozen
+            ) {
+                old_execute.apply(this, arguments);
+            }
+        }
+    }
+
+    function set_state(cell, state) {
+        if (cell instanceof CodeCell) {
+            if (cell.metadata.run_control === undefined)
+                cell.metadata.run_control = {};
+            if (state === undefined)
+                state = 'normal';
+            switch(state) {
+                case 'normal':
+                    var new_run_control_values = {
+                        read_only : false,
+                        frozen : false
+                    };
+                    var bg = "";
+                    break;
+                case 'read_only':
+                    var new_run_control_values = {
+                            read_only : true,
+                            frozen : false
+                    };
+                    var bg = "#FFFEF0";
+                    break;
+                case 'frozen':
+                    var new_run_control_values = {
+                        read_only : true,
+                        frozen : true
+                    };
+                    var bg = "#f0feff";
+                    break;
+            }
+            $.extend(cell.metadata.run_control, new_run_control_values);
+            cell.code_mirror.setOption('readOnly', cell.metadata.run_control.read_only);
+            var prompt = cell.element.find('div.input_area');
+            prompt.css("background-color", bg);
+        }
+    }
+
+    function set_state_selected (state) {
+        var cells = Jupyter.notebook.get_selected_cells();
+        for (var i = 0; i < cells.length; i++) {
+            set_state(cells[i], state)
+        }
+    }
+
+    function make_normal_selected () {
+        set_state_selected('normal');
+    }
+
+    function make_read_only_selected () {
+        set_state_selected('read_only');
+    }
+
+    function make_frozen_selected () {
+        set_state_selected('frozen');
+    }
+
+
+    function initialize_states () {
+        var cells = Jupyter.notebook.get_cells();
+        for (var i in cells) {
+            var cell = cells[i];
+            if (cell instanceof CodeCell) {
+                if (cell.metadata.run_control != undefined) {
+                    if (cell.metadata.run_control.read_only) {
+                        if (cell.metadata.run_control.frozen) {
+                            set_state(cell, 'frozen')
+                        } else {
+                            set_state(cell, 'read_only')
+                        }
+                    } else {
+                        set_state(cell, 'normal')
+                    }
+                } else {
+                    set_state(cell, 'normal');
+                }
+            }
+        }
+    }
+
+    function load_extension () {
+        Jupyter.toolbar.add_buttons_group([
+            {
+                id : 'make_normal',
+                label : 'lift restrictions from selected cells',
+                icon : 'fa-unlock-alt',
+                callback : make_normal_selected
+            },
+            {
+                id : 'make_read_only',
+                label : 'make selected cells read-only',
+                icon: 'fa-lock',
+                callback : make_read_only_selected
+            },
+            {
+                id : 'freeze_cells',
+                label : 'freeze selected cells',
+                icon : 'fa-asterisk',
+                callback : make_frozen_selected
+            }
+        ]);
+
+        if (typeof Jupyter.notebook === "undefined") {
+            events.on("notebook_loaded.Notebook", initialize_states)
+        } else {
+            initialize_states();
+        }
+
+        patch_CodeCell_execute();
+    }
+
+    return {
+        load_jupyter_extension : load_extension,
+        load_ipython_extension : load_extension
+    }
 });

--- a/src/jupyter_contrib_nbextensions/nbextensions/freeze/main.js
+++ b/src/jupyter_contrib_nbextensions/nbextensions/freeze/main.js
@@ -87,19 +87,11 @@ define([
         for (var i in cells) {
             var cell = cells[i];
             if (cell instanceof CodeCell) {
-                if (cell.metadata.run_control != undefined) {
-                    if (cell.metadata.run_control.read_only) {
-                        if (cell.metadata.run_control.frozen) {
-                            set_state(cell, 'frozen')
-                        } else {
-                            set_state(cell, 'read_only')
-                        }
-                    } else {
-                        set_state(cell, 'normal')
-                    }
-                } else {
-                    set_state(cell, 'normal');
+                var state = 'normal';
+                if (cell.metadata.run_control != undefined && cell.metadata.run_control.read_only) {
+                    state = cell.metadata.run_control.frozen ? 'frozen' : 'read_only';
                 }
+                set_state(cell, state);
             }
         }
     }

--- a/src/jupyter_contrib_nbextensions/nbextensions/freeze/main.js
+++ b/src/jupyter_contrib_nbextensions/nbextensions/freeze/main.js
@@ -101,7 +101,7 @@ define([
 
     function initialize_states () {
         var cells = Jupyter.notebook.get_cells();
-        for (var i in cells) {
+        for (var i = 0; i < cells.length; i++) {
             var cell = cells[i];
             if (cell instanceof CodeCell || cell instanceof MarkdownCell) {
                 var state = 'normal';

--- a/src/jupyter_contrib_nbextensions/nbextensions/freeze/main.js
+++ b/src/jupyter_contrib_nbextensions/nbextensions/freeze/main.js
@@ -44,45 +44,49 @@ define([
     }
 
     function set_state(cell, state) {
-        if (cell instanceof CodeCell || cell instanceof MarkdownCell) {
-            if (cell.metadata.run_control === undefined)
-                cell.metadata.run_control = {};
-            if (state === undefined)
-                state = 'normal';
-            switch(state) {
-                case 'normal':
-                    var new_run_control_values = {
-                        read_only : false,
-                        frozen : false
-                    };
-                    var bg = "";
-                    break;
-                case 'read_only':
-                    var new_run_control_values = {
-                            read_only : true,
-                            frozen : false
-                    };
-                    var bg = "#FFFEF0";
-                    break;
-                case 'frozen':
-                    var new_run_control_values = {
-                        read_only : true,
-                        frozen : true
-                    };
-                    var bg = "#f0feff";
-                    break;
-            }
-            $.extend(cell.metadata.run_control, new_run_control_values);
-            cell.code_mirror.setOption('readOnly', cell.metadata.run_control.read_only);
-            var prompt = cell.element.find('div.input_area');
-            prompt.css("background-color", bg);
+        if (!(cell instanceof CodeCell || cell instanceof MarkdownCell)) {
+            return
         }
+
+        if (cell.metadata.run_control === undefined)
+            cell.metadata.run_control = {};
+
+        state = state || 'normal';
+        var new_run_control_values;
+        var bg;
+        switch (state) {
+            case 'normal':
+                new_run_control_values = {
+                    read_only: false,
+                    frozen: false
+                };
+                bg = "";
+                break;
+            case 'read_only':
+                new_run_control_values = {
+                    read_only: true,
+                    frozen: false
+                };
+                bg = "#FFFEF0";
+                break;
+            case 'frozen':
+                new_run_control_values = {
+                    read_only: true,
+                    frozen: true
+                };
+                bg = "#f0feff";
+                break;
+        }
+        $.extend(cell.metadata.run_control, new_run_control_values);
+        cell.code_mirror.setOption('readOnly', cell.metadata.run_control.read_only);
+        var prompt = cell.element.find('div.input_area');
+        prompt.css("background-color", bg);
     }
 
     function set_state_selected (state) {
         var cells = Jupyter.notebook.get_selected_cells();
         for (var i = 0; i < cells.length; i++) {
-            set_state(cells[i], state)
+            set_state(cells[i], state);
         }
     }
 
@@ -98,18 +102,18 @@ define([
         set_state_selected('frozen');
     }
 
-
     function initialize_states () {
         var cells = Jupyter.notebook.get_cells();
         for (var i = 0; i < cells.length; i++) {
             var cell = cells[i];
-            if (cell instanceof CodeCell || cell instanceof MarkdownCell) {
-                var state = 'normal';
-                if (cell.metadata.run_control != undefined && cell.metadata.run_control.read_only) {
-                    state = cell.metadata.run_control.frozen ? 'frozen' : 'read_only';
-                }
-                set_state(cell, state);
+            if (!(cell instanceof CodeCell || cell instanceof MarkdownCell)) {
+                continue;
             }
+            var state = 'normal';
+            if (cell.metadata.run_control != undefined && cell.metadata.run_control.read_only) {
+                state = cell.metadata.run_control.frozen ? 'frozen' : 'read_only';
+            }
+            set_state(cell, state);
         }
     }
 
@@ -136,7 +140,7 @@ define([
         ]);
 
         if (typeof Jupyter.notebook === "undefined") {
-            events.on("notebook_loaded.Notebook", initialize_states)
+            events.on("notebook_loaded.Notebook", initialize_states);
         } else {
             initialize_states();
         }
@@ -148,5 +152,5 @@ define([
     return {
         load_jupyter_extension : load_extension,
         load_ipython_extension : load_extension
-    }
+    };
 });

--- a/src/jupyter_contrib_nbextensions/nbextensions/freeze/readme.md
+++ b/src/jupyter_contrib_nbextensions/nbextensions/freeze/readme.md
@@ -1,6 +1,12 @@
 # Freeze
 
-This extension allows to make cells read-only or frozen. If a cell is read-only, it can be executed, but its input cannot be changed. Frozen cells cannot be either altered or executed.
+This extension allows to make cells read-only or frozen.
+
+If a code cell is read-only, it can be executed, but its input cannot be changed.
+Frozen code cells cannot be either altered or executed.
+
+If a markdown cell is read-only, its input can be viewed by double-clicking on it, but cannot be changed.
+Frozen markdown cells' input cannot be viewed by double-clicking.
 
 To change cells' state, select them and press corresponding button.
 


### PR DESCRIPTION
I've received a request to make Freeze work with markdown cells, so here it is.
Read-only state for markdown cells equals "input can be unrendered, but cannot be edited", frozen state equals "input cannot be unrendered".
I've also done some cleanup along the way.

Thanks in advance.