### PR TITLE
Use jupyter_nbextensions_configurator's actual install app

### DIFF
--- a/src/jupyter_contrib_nbextensions/install.py
+++ b/src/jupyter_contrib_nbextensions/install.py
@@ -9,7 +9,10 @@ import errno
 import os
 
 import psutil
-from jupyter_contrib_core.notebook_compat import nbextensions, serverextensions
+from jupyter_contrib_core.notebook_compat import nbextensions
+from jupyter_nbextensions_configurator import (
+    EnableJupyterNbextensionsConfiguratorApp,
+)
 from traitlets.config import Config
 from traitlets.config.manager import BaseJSONConfigManager
 
@@ -64,9 +67,9 @@ def toggle_install(install, user=False, sys_prefix=False, overwrite=False,
 
     # Configure the jupyter_nbextensions_configurator serverextension to load
     if install:
-        serverextensions.toggle_serverextension_python(
-            'jupyter_nbextensions_configurator',
-            enabled=True, user=user, sys_prefix=sys_prefix, logger=logger)
+        conf_app = EnableJupyterNbextensionsConfiguratorApp(
+            user=user, sys_prefix=sys_prefix, symlink=symlink, logger=logger)
+        conf_app.start()
 
     # nbextensions:
     kwargs = dict(user=user, sys_prefix=sys_prefix, prefix=prefix,

--- a/src/jupyter_contrib_nbextensions/install.py
+++ b/src/jupyter_contrib_nbextensions/install.py
@@ -10,7 +10,7 @@ import os
 
 import psutil
 from jupyter_contrib_core.notebook_compat import nbextensions
-from jupyter_nbextensions_configurator import (
+from jupyter_nbextensions_configurator.application import (
     EnableJupyterNbextensionsConfiguratorApp,
 )
 from traitlets.config import Config
@@ -80,7 +80,7 @@ def toggle_install(install, user=False, sys_prefix=False, overwrite=False,
             overwrite=overwrite, symlink=symlink, **kwargs)
         # enable contrib_nbextensions_help_item (item in help menu)
         nbextensions.enable_nbextension('notebook',
-                'contrib_nbextensions_help_item/main', 
+                'contrib_nbextensions_help_item/main',
                 user=user, sys_prefix=sys_prefix)
     else:
         nbextensions.uninstall_nbextension_python(

--- a/tests/test_application.py
+++ b/tests/test_application.py
@@ -108,8 +108,14 @@ class AppTest(TestCase):
                 conf = Config(json.load(f))
             confstrip = {}
             confstrip.update(conf)
+            # strip out config values we are ok to have remain
             confstrip.pop('NotebookApp', None)
             confstrip.pop('version', None)
+            conf_exts = confstrip.get('load_extensions', {})
+            conf_exts.pop('nbextensions_configurator/config_menu/main', None)
+            conf_exts.pop('nbextensions_configurator/tree_tab/main', None)
+            if not conf_exts:
+                confstrip.pop('load_extensions', None)
             nt.assert_false(confstrip, 'disable should leave config empty.')
 
     def _get_default_check_kwargs(self, argv=None, dirs=None):


### PR DESCRIPTION
rather than just enabling the serverextension, as that results in the configurator's tab & menu nbextensions not being enabled. By adopting the configurator's install, we maintain consistency.