### PR TITLE
Fix limit output missing braces

### DIFF
--- a/src/jupyter_contrib_nbextensions/nbextensions/limit_output/limit-output.yaml
+++ b/src/jupyter_contrib_nbextensions/nbextensions/limit_output/limit-output.yaml
@@ -15,4 +15,4 @@ Parameters:
 - name: limit_output_message
   description: Message to append when output is limited
   input_type: text
-  default: '<b>limit_output extension: Maximum message size exceeded</b>'
+  default: '<b>limit_output extension: Maximum message size of {limit_output_length} exceeded with {output_length} characters</b>'

--- a/src/jupyter_contrib_nbextensions/nbextensions/limit_output/main.js
+++ b/src/jupyter_contrib_nbextensions/nbextensions/limit_output/main.js
@@ -19,7 +19,7 @@ define([
         // maximum number of characters the output area is allowed to print
         limit_output : 10000,
         // message to print when output is limited
-        limit_output_message : '<b>limit_output extension: Maximum message size exceeded</b>'
+        limit_output_message : '<b>limit_output extension: Maximum message size of {limit_output_length} exceeded with {output_length} characters</b>'
     };
 
     // to be called once config is loaded, this updates default config vals
@@ -47,20 +47,27 @@ define([
                         (msg.content.data['text/plain'] === undefined) ? 0 : String(msg.content.data['text/plain']).length,
                         (msg.content.data['text/html'] === undefined) ? 0 : String(msg.content.data['text/html']).length )
                 }
-                if (count > MAX_CHARACTERS)
-                    console.log("limit_output: output exceeded", MAX_CHARACTERS, "characters. Further output muted.");
+                if (count > MAX_CHARACTERS) {
+                    console.log("limit_output: output", count, "exceeded", MAX_CHARACTERS, "characters. Further output muted.");
                     if (msg.header.msg_type === "stream") {
                         msg.content.text = msg.content.text.substr(0, MAX_CHARACTERS)
                     } else {
-                        if (msg.content.data['text/plain'] !== undefined) msg.content.data['text/plain'] = msg.content.data['text/plain'].substr(0, MAX_CHARACTERS);
-                        if (msg.content.data['text/html'] !== undefined) msg.content.data['text/html'] = msg.content.data['text/html'].substr(0, MAX_CHARACTERS);
+                        if (msg.content.data['text/plain'] !== undefined) {
+                            msg.content.data['text/plain'] = msg.content.data['text/plain'].substr(0, MAX_CHARACTERS);
+                        }
+                        if (msg.content.data['text/html'] !== undefined) {
+                            msg.content.data['text/html'] = msg.content.data['text/html'].substr(0, MAX_CHARACTERS);
+                        }
                     }
                     var limitmsg = {};
                     limitmsg.data = [];
-                    limitmsg.data['text/html'] = params.limit_output_message;
+                    // allow simple substitutions for output length for quick debugging
+                    limitmsg.data['text/html'] = params.limit_output_message.replace("{limit_output_length}", MAX_CHARACTERS)
+                                                                            .replace("{output_length}", count);
                     this._handle_output(msg);
                     return this.append_display_data(limitmsg);
                 }
+            }
             return this._handle_output(msg);
         };
 

--- a/src/jupyter_contrib_nbextensions/nbextensions/limit_output/readme.md
+++ b/src/jupyter_contrib_nbextensions/nbextensions/limit_output/readme.md
@@ -25,3 +25,6 @@ Three types of messages are intercepted: `stream`, `execute_result`, `display_da
 For `stream`- type messages, the text string length is limited to `limit_output` number of characters
 For other message types, `text/plain` and `text/html` content length is counted` and if either
 exceeds `limit_output` charaters, will be truncated.
+
+The `limit_output_message` can be formatted to display the `limit_output` length and the current `output_length`,
+respectively using the replacement fields `{limit_output_length}` and `{output_length}`.


### PR DESCRIPTION
There are missing braces causing the indentation to not match the code flow. Due to the currently mismatching braces, the limit output extension will usually display an error message indicating it is limiting output, although it is not (but not indicating such in console.log).

Fixed this bug and also added ability to display the current and maximum output lengths in the error message to make this type of error easier to debug in future.
