### PR TITLE
toc2: update for html export + notebook menus set to the left

### DIFF
--- a/src/jupyter_contrib_nbextensions/nbextensions/toc2/main.css
+++ b/src/jupyter_contrib_nbextensions/nbextensions/toc2/main.css
@@ -10,11 +10,11 @@ by selecting a color in the nbextension-configurator*/
 #navigate_menu li a:hover {background-color: #f1f1f1}
 
 
-/* Move menus and tooolbar to the left, following @Kevin-McIsaac suggestion */
+/* Move menus and tooolbar to the left, following @Kevin-McIsaac suggestion 
 div#menubar-container, div#header-container {
 width: auto;
 padding-left: 20px;
-}
+}*/
 
 #navigate_menu {
   /*display: block;*/

--- a/src/jupyter_contrib_nbextensions/nbextensions/toc2/main.css
+++ b/src/jupyter_contrib_nbextensions/nbextensions/toc2/main.css
@@ -1,27 +1,20 @@
 /*extracted from https://gist.github.com/magican/5574556*/
 
 
-/*#toc-level0 li > a:hover {  display: block; background-color: #DAA520}*/
+/*background color for links when you mouse over it 
+This style is used on export, but can be overwritted in the livenotebook 
+by selecting a color in the nbextension-configurator*/
+#toc-level0 li > a:hover {  display: block; background-color: #DAA520} 
 
 #toc-level0  a {color: #333333; text-decoration: none;}
 #navigate_menu li a:hover {background-color: #f1f1f1}
 
-/*#Navigate_menu {
-  list-style-type: none;
-  max-width: 500px; 
-  min-width: 100px; 
-  width: 250px; 
-  overflow: auto;
-}
 
-#navigate_menu {
-  overflow: hidden;
+/* Move menus and tooolbar to the left, following @Kevin-McIsaac suggestion */
+div#menubar-container, div#header-container {
+width: auto;
+padding-left: 20px;
 }
-
-#Navigate_menu {
-  list-style-type: none;
-  overflow: auto;
-}*/
 
 #navigate_menu {
   /*display: block;*/
@@ -164,7 +157,10 @@
     color: black;
 }
 
-/*.toc-item-highlight-select  {background-color: Gold} 
+/*
+These colors are now specified in js, after reading the extension's config stored in system
+and updated using the nbextension-configurator
+.toc-item-highlight-select  {background-color: Gold} 
 .toc-item-highlight-execute  {background-color: red} 
 .toc-item-highlight-execute.toc-item-highlight-select   {background-color: Gold} */
 

--- a/src/jupyter_contrib_nbextensions/nbextensions/toc2/main.js
+++ b/src/jupyter_contrib_nbextensions/nbextensions/toc2/main.js
@@ -22,6 +22,7 @@ define(["require", "jquery", "base/js/namespace",  'services/config',
              "toc_section_display": "block",
              'sideBar':true,
 	           'navigate_menu':true,
+             'moveMenuLeft': true,
              'colors': {'hover_highlight': '#DAA520',
              'selected_highlight': '#FFD700',
              'running_highlight': '#FF0000'}
@@ -60,12 +61,19 @@ define(["require", "jquery", "base/js/namespace",  'services/config',
       cfg = IPython.notebook.metadata.toc = $.extend(true, cfg,
           IPython.notebook.metadata.toc);
       // excepted colors that are taken globally (if defined)
-      cfg.colors = IPython.notebook.metadata.toc.colors = $.extend(true, {}, initial_cfg.colors);
+      cfg.colors = IPython.notebook.metadata.toc.colors = $.extend(true, {}, initial_cfg.colors);      
       try
          {cfg.colors = IPython.notebook.metadata.toc.colors = $.extend(true, cfg.colors, config.data.toc2.colors);  }
       catch(e) {}
+      // and moveMenuLeft taken globally (if it exists, otherwise default)
+      cfg.moveMenuLeft = IPython.notebook.metadata.toc.moveMenuLeft = initial_cfg.moveMenuLeft;
+      if (config.data.toc2) {
+        if (typeof config.data.toc2.moveMenuLeft !== "undefined") {
+            cfg.moveMenuLeft = IPython.notebook.metadata.toc.moveMenuLeft = config.data.toc2.moveMenuLeft; 
+        }
+      }
       // create highlights style section in document
-      create_highlights_css()
+      create_additional_css()
       // call callbacks
       callback && callback();
       st.config_loaded = true;
@@ -112,12 +120,17 @@ define(["require", "jquery", "base/js/namespace",  'services/config',
   };
   
 
-  function create_highlights_css() {
+  function create_additional_css() {
       var sheet = document.createElement('style')
       sheet.innerHTML = "#toc-level0 li > a:hover {  display: block; background-color: " + cfg.colors.hover_highlight + " }\n" +
           ".toc-item-highlight-select  {background-color: " + cfg.colors.selected_highlight + "}\n" +
           ".toc-item-highlight-execute  {background-color: " + cfg.colors.running_highlight + "}\n" +
-          ".toc-item-highlight-execute.toc-item-highlight-select   {background-color: " + cfg.colors.selected_highlight + "}"
+          ".toc-item-highlight-execute.toc-item-highlight-select   {background-color: " + cfg.colors.selected_highlight + "}"       
+      if (cfg.moveMenuLeft){
+        sheet.innerHTML += "div#menubar-container, div#header-container {\n"+
+            "width: auto;\n"+
+            "padding-left: 20px; }"
+      }          
       document.body.appendChild(sheet);
   }
 

--- a/src/jupyter_contrib_nbextensions/nbextensions/toc2/toc2.yaml
+++ b/src/jupyter_contrib_nbextensions/nbextensions/toc2/toc2.yaml
@@ -32,6 +32,10 @@ Parameters:
   description: Display Table of Contents as a navigation menu
   input_type: checkbox
   default: true
+- name: toc2.moveMenuLeft
+  description: Move notebook's title and menu on the left instead of being centered -- This provides a better look when the toc/sidebar is present
+  input_type: checkbox
+  default: true    
 - name: toc2.colors.hover_highlight
   input_type: color
   description: Hover color in toc


### PR DESCRIPTION
- Since previous PR, the highlighting colors for the sections in toc with selected/edited/running cells are user configurable and are set directly by javascript (config is read from system). However, when exporting to html, the style is not defined. This PR simply adds a default config (for hover highlighting) which is used by documents exported to html and overwritten in the live notebook.   

- In #650, @Kevin-McIsaac suggested to move title/menus/icons on left. 
Indeed, since the introduction of the toc sidebar, the toc2 extension resizes the main container to fit the whole window and add the sidebar. Centered menus then sometimes look odd. I agree with the suggestion. The PR adds a small styling in toc css to move the menu to the left. However, I am not sure if it should be done here, or left to the users, or put as a configuration option.  Thoughts? 
