### PR TITLE
fix tox env pypi_upload

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -143,7 +143,7 @@ commands = python setup.py sdist bdist_wheel
 skip_install = true
 whitelist_externals = bash
 deps = twine
-commands = bash -c \"twine upload dist/*\"
+commands = bash -c \"twine upload dist/jupyter_contrib_nbextensions*\"
 
 [testenv:condarecipe]
 skip_install = true


### PR DESCRIPTION
we don't want to upload dist/docs, as it's not a package