### PR TITLE
toc2: html export -- take into account number_section 

### DIFF
--- a/src/jupyter_contrib_nbextensions/templates/toc2.tpl
+++ b/src/jupyter_contrib_nbextensions/templates/toc2.tpl
@@ -9,6 +9,15 @@
 <script type="text/javascript" src="http://ajax.googleapis.com/ajax/libs/jquery/1.9.1/jquery.min.js"></script>
 <script type="text/javascript" src="http://ajax.googleapis.com/ajax/libs/jqueryui/1.9.1/jquery-ui.min.js"></script>
 
+<style>  /* defined here in case the main.css below cannot be loaded */
+.lev1 {margin-left: 80px}
+.lev2 {margin-left: 100px}
+.lev3 {margin-left: 120px}
+.lev4 {margin-left: 140px}
+.lev5 {margin-left: 160px}
+.lev6 {margin-left: 180px}
+</style>
+
 <link rel="stylesheet" type="text/css" href="https://rawgit.com/ipython-contrib/jupyter_contrib_nbextensions/master/src/jupyter_contrib_nbextensions/nbextensions/toc2/main.css">
 
 <script src="https://rawgit.com/ipython-contrib/jupyter_contrib_nbextensions/master/src/jupyter_contrib_nbextensions/nbextensions/toc2/toc2.js"></script>
@@ -16,12 +25,12 @@
 <script>
 $( document ).ready(function(){
 
-            var cfg={'threshold':6,     // depth of toc (number of levels)
+            var cfg={'threshold':{{ nb.get('metadata', {}).get('toc', {}).get('threshold', '3') }},     // depth of toc (number of levels)
              'number_sections': {{ 'true' if nb.get('metadata', {}).get('toc', {}).get('number_sections', False) else 'false' }},  // sections numbering
              'toc_cell': false,          // useless here
              'toc_window_display': true, // display the toc window
              "toc_section_display": "block", // display toc contents in the window
-             'sideBar':true,             // sidebar or floating window
+             'sideBar':{{ 'true' if nb.get('metadata', {}).get('toc', {}).get('sideBar', False) else 'false' }},             // sidebar or floating window
              'navigate_menu':false       // navigation menu (only in liveNotebook -- do not change)
             }
 

--- a/src/jupyter_contrib_nbextensions/templates/toc2.tpl
+++ b/src/jupyter_contrib_nbextensions/templates/toc2.tpl
@@ -16,7 +16,7 @@
 <script>
 $( document ).ready(function(){
             var cfg={'threshold':6,     // depth of toc (number of levels)
-             'number_sections':true,    // sections numbering
+             'number_sections': "{{nb['metadata']['toc']['number_sections']}}"=="True" ? true : false,  // sections numbering
              'toc_cell':false,          // useless here
              'toc_window_display':true, // display the toc window
              "toc_section_display": "block", // display toc contents in the window

--- a/src/jupyter_contrib_nbextensions/templates/toc2.tpl
+++ b/src/jupyter_contrib_nbextensions/templates/toc2.tpl
@@ -15,10 +15,11 @@
 
 <script>
 $( document ).ready(function(){
+
             var cfg={'threshold':6,     // depth of toc (number of levels)
-             'number_sections': "{{nb['metadata']['toc']['number_sections']}}"=="True" ? true : false,  // sections numbering
-             'toc_cell':false,          // useless here
-             'toc_window_display':true, // display the toc window
+             'number_sections': {{ 'true' if nb.get('metadata', {}).get('toc', {}).get('number_sections', False) else 'false' }},  // sections numbering
+             'toc_cell': false,          // useless here
+             'toc_window_display': true, // display the toc window
              "toc_section_display": "block", // display toc contents in the window
              'sideBar':true,             // sidebar or floating window
              'navigate_menu':false       // navigation menu (only in liveNotebook -- do not change)


### PR DESCRIPTION
OK, here is a possibility to address #808 
Just read the parameter in notebook's metadata and populate the parameter in the export template. 

However, this has a drawback and I am not sure that it should be merged: if the metadata toc (the toc section in metadata) does not exist, then conversion fail; even if we try to catch the exception; since actually the exception arises in the jinja2 processing. 
I think that it can be useful to convert notebook using the `html_toc`parameter even if they have not be created with toc2 activated, since it still generates the toc in that case. Thoughts?  