### PR TITLE
[init_cell] updates

### DIFF
--- a/src/jupyter_contrib_nbextensions/nbextensions/init_cell/README.md
+++ b/src/jupyter_contrib_nbextensions/nbextensions/init_cell/README.md
@@ -1,5 +1,34 @@
 init_cell
 =========
 
-Add a cell toolbar selector to mark cells as 'initialization' cells. 
-Such initialization cells are run on notebook load, or on clicking the provided button in the main toolbar.
+Add a cell toolbar selector to mark cells as 'initialization' cells .
+Such initialization cells are run:
+
+ * on clicking the provided button in the main toolbar
+   ![main toolabr button](icon.png)
+ * by default, on kernel ready notification. This is configurable (see options section).
+
+
+Options
+-------
+
+This nbextension provides option configurable using the
+[jupyter_nbextensions_configurator](https://github.com/Jupyter-contrib/jupyter_nbextensions_configurator).
+
+The running of initialization cells on kernel ready notification can be
+frustrating if your kernel is attached to multiple frontends, or is persistent
+between frontend reloads (e.g. reloading the notebook browser page without
+killing the kernel).
+As such, the option `init_cell.run_on_kernel_ready` in the notebook config
+section controls whether this behaviour occurs.
+
+
+Internals
+---------
+
+Cells are marked as initialization cells in their metadata, as
+
+  cell.metadata.init_cell = true
+
+The running of initialization cells on kernel ready is bound to the Jupyter
+event `kernel_ready.Kernel`.

--- a/src/jupyter_contrib_nbextensions/nbextensions/init_cell/README.md
+++ b/src/jupyter_contrib_nbextensions/nbextensions/init_cell/README.md
@@ -21,6 +21,8 @@ between frontend reloads (e.g. reloading the notebook browser page without
 killing the kernel).
 As such, the option `init_cell.run_on_kernel_ready` in the notebook config
 section controls whether this behaviour occurs.
+The server's config value can also be overridden on a per-notebook basis by
+setting `notebook.metadata.init_cell.run_on_kernel_ready`.
 
 
 Internals

--- a/src/jupyter_contrib_nbextensions/nbextensions/init_cell/README.md
+++ b/src/jupyter_contrib_nbextensions/nbextensions/init_cell/README.md
@@ -6,7 +6,10 @@ Such initialization cells are run:
 
  * on clicking the provided button in the main toolbar
    ![main toolabr button](icon.png)
- * by default, on kernel ready notification. This is configurable (see options section).
+ * by default, on kernel ready notification for trusted notebooks.
+   This is configurable (see options section).
+   In untrusted notebooks, a warning is displayed if the cells would otherwise
+   have been run.
 
 
 Options

--- a/src/jupyter_contrib_nbextensions/nbextensions/init_cell/init_cell.yaml
+++ b/src/jupyter_contrib_nbextensions/nbextensions/init_cell/init_cell.yaml
@@ -4,4 +4,13 @@ Name: Initialization cells
 Main: main.js
 Icon: icon.png
 Link: README.md
-Description: Add a cell toolbar selector to mark cells as 'initialization' cells. Such initialization cells are run on notebook load, or on clicking the provided button in the main toolbar
+Description: |
+  Add a cell toolbar selector to mark cells as 'initialization' cells. Such
+  initialization cells can be run by on clicking the provided button in the
+  main toolbar, or configurably, run automatically on notebook load.
+Parameters:
+- name: init_cell.run_on_kernel_ready
+  description: |
+    Run input cells whenever a kernel_ready.Kernel event is fired. See readme for further details.
+  input_type: checkbox
+  default: true

--- a/src/jupyter_contrib_nbextensions/nbextensions/init_cell/main.js
+++ b/src/jupyter_contrib_nbextensions/nbextensions/init_cell/main.js
@@ -3,10 +3,15 @@ define(function (require, exports, module) {
     var $ = require('jquery');
     var events = require('base/js/events');
     var Jupyter = require('base/js/namespace');
+    var utils = require('base/js/utils');
     var CellToolbar = require('notebook/js/celltoolbar').CellToolbar;
     var CodeCell = require('notebook/js/codecell').CodeCell;
+    var ConfigSection = require('services/config').ConfigSection;
 
     var log_prefix = '[' + module.id + ']';
+    var options = { // updated from server's config on loading nbextension
+        run_on_kernel_ready: true,
+    };
 
     var init_cell_ui_callback = CellToolbar.utils.checkbox_ui_generator(
         'Initialisation Cell',
@@ -55,8 +60,27 @@ define(function (require, exports, module) {
         // Register a preset of UI elements forming a cell toolbar.
         CellToolbar.register_preset('Initialisation Cell', ['init_cell.is_init_cell']);
 
-        // whenever a (new) kernel  becomes ready, run all initialization cells
-        events.on('kernel_ready.Kernel', run_init_cells);
+        var base_url = utils.get_body_data('baseUrl');
+        var conf_section = new ConfigSection('notebook', {'base_url': base_url});
+        conf_section.load()
+            .then(
+                function on_success (new_config_data) {
+                    // update options from server config
+                    $.extend(true, options, new_config_data.init_cell);
+                }, function on_error (err) {
+                    console.warn(log_prefix, 'error loading options from config:', err);
+                    console.warn(log_prefix, 'Using default options:', options);
+                })
+            .then(function () {
+                if (options.run_on_kernel_ready) {
+                    if (Jupyter.notebook && Jupyter.notebook.kernel && Jupyter.notebook.kernel.info_reply.status === 'ok') {
+                        // kernel is already ready
+                        run_init_cells();
+                    }
+                    // whenever a (new) kernel  becomes ready, run all initialization cells
+                    events.on('kernel_ready.Kernel', run_init_cells);
+                }
+            });
     };
 
     return {

--- a/src/jupyter_contrib_nbextensions/nbextensions/init_cell/main.js
+++ b/src/jupyter_contrib_nbextensions/nbextensions/init_cell/main.js
@@ -67,6 +67,23 @@ define(function (require, exports, module) {
                 function on_success (new_config_data) {
                     // update options from server config
                     $.extend(true, options, new_config_data.init_cell);
+                    // update from metadata
+                    return new Promise(function (resolve, reject) {
+                        function update_options_from_nb_metadata () {
+                            var md_opts = Jupyter.notebook.metadata.init_cell;
+                            if (md_opts !== undefined) {
+                                console.log(log_prefix, 'updating options from notebook metadata:', md_opts);
+                                $.extend(true, options, md_opts);
+                            }
+                            resolve(options);
+                        }
+                        if (Jupyter.notebook) {
+                            update_options_from_nb_metadata();
+                        }
+                        else {
+                            events.on('notebook_loaded.Notebook', update_options_from_nb_metadata);
+                        }
+                    });
                 }, function on_error (err) {
                     console.warn(log_prefix, 'error loading options from config:', err);
                     console.warn(log_prefix, 'Using default options:', options);

--- a/src/jupyter_contrib_nbextensions/nbextensions/init_cell/main.js
+++ b/src/jupyter_contrib_nbextensions/nbextensions/init_cell/main.js
@@ -6,34 +6,37 @@ define(function (require, exports, module) {
     var CellToolbar = require('notebook/js/celltoolbar').CellToolbar;
     var CodeCell = require('notebook/js/codecell').CodeCell;
 
+    var log_prefix = '[' + module.id + ']';
+
     var init_cell_ui_callback = CellToolbar.utils.checkbox_ui_generator(
         'Initialisation Cell',
         // setter
-        function(cell, value) {
+        function (cell, value) {
             cell.metadata.init_cell = value;
         },
         // getter
-        function(cell) {
+        function (cell) {
              // if init_cell is undefined, it'll be interpreted as false anyway
             return cell.metadata.init_cell;
         }
     );
 
-    var run_init_cells = function(){
-        console.log('init_cell : running all initialization cells');
+    function run_init_cells () {
+        console.log(log_prefix, 'running all initialization cells');
         var num = 0;
         var cells = Jupyter.notebook.get_cells();
-        for(var ii in cells) {
+        for (var ii = 0; ii < cells.length; ii++) {
             var cell = cells[ii];
             if ((cell instanceof CodeCell) && cell.metadata.init_cell === true ) {
                 cell.execute();
                 num++;
             }
         }
-        console.log('init_cell : finished running ' + num + ' initialization cell' + (num !== 1 ? 's' : ''));
-    };
+        console.log(log_prefix, 'finished running ' + num + ' initialization cell' + (num !== 1 ? 's' : ''));
+    }
 
     var load_ipython_extension = function() {
+        // register action
         var prefix = 'auto';
         var action_name = 'run-initialization-cells';
         var action = {
@@ -44,6 +47,7 @@ define(function (require, exports, module) {
         };
         var action_full_name = Jupyter.notebook.keyboard_manager.actions.register(action, action_name, prefix);
 
+        // add toolbar button
         Jupyter.toolbar.add_buttons_group([action_full_name]);
 
         // Register a callback to create a UI element for a cell toolbar.

--- a/src/jupyter_contrib_nbextensions/nbextensions/init_cell/main.js
+++ b/src/jupyter_contrib_nbextensions/nbextensions/init_cell/main.js
@@ -1,6 +1,7 @@
 define(function (require, exports, module) {
     // requirments
     var $ = require('jquery');
+    var dialog = require('base/js/dialog');
     var events = require('base/js/events');
     var Jupyter = require('base/js/namespace');
     var utils = require('base/js/utils');
@@ -90,6 +91,17 @@ define(function (require, exports, module) {
                 })
             .then(function () {
                 if (options.run_on_kernel_ready) {
+                    if (!Jupyter.notebook.trusted) {
+                        dialog.modal({
+                            title : 'Initialization cells in untrusted notebook',
+                            body : 'This notebook is not trusted, so initialization cells will not be automatically run on kernel load. You can still run them manually, though.',
+                            buttons: {'OK': {'class' : 'btn-primary'}},
+                            notebook: Jupyter.notebook,
+                            keyboard_manager: Jupyter.keyboard_manager,
+                        });
+                        return;
+                    }
+
                     if (Jupyter.notebook && Jupyter.notebook.kernel && Jupyter.notebook.kernel.info_reply.status === 'ok') {
                         // kernel is already ready
                         run_init_cells();

--- a/src/jupyter_contrib_nbextensions/nbextensions/init_cell/main.js
+++ b/src/jupyter_contrib_nbextensions/nbextensions/init_cell/main.js
@@ -1,15 +1,12 @@
-define([
-    'jquery',
-    'base/js/namespace',
-    'base/js/events'
-], function (
-    $,
-    IPython,
-    events
-) {
-    var ctb = IPython.CellToolbar;
+define(function (require, exports, module) {
+    // requirments
+    var $ = require('jquery');
+    var events = require('base/js/events');
+    var Jupyter = require('base/js/namespace');
+    var CellToolbar = require('notebook/js/celltoolbar').CellToolbar;
+    var CodeCell = require('notebook/js/codecell').CodeCell;
 
-    var init_cell_ui_callback = ctb.utils.checkbox_ui_generator(
+    var init_cell_ui_callback = CellToolbar.utils.checkbox_ui_generator(
         'Initialisation Cell',
         // setter
         function(cell, value) {
@@ -25,10 +22,10 @@ define([
     var run_init_cells = function(){
         console.log('init_cell : running all initialization cells');
         var num = 0;
-        var cells = IPython.notebook.get_cells();
+        var cells = Jupyter.notebook.get_cells();
         for(var ii in cells) {
             var cell = cells[ii];
-            if((cell instanceof IPython.CodeCell) && cell.metadata.init_cell === true ) {
+            if ((cell instanceof CodeCell) && cell.metadata.init_cell === true ) {
                 cell.execute();
                 num++;
             }
@@ -45,14 +42,14 @@ define([
             help_index : 'zz',
             handler : run_init_cells
         };
-        var action_full_name = IPython.notebook.keyboard_manager.actions.register(action, action_name, prefix);
+        var action_full_name = Jupyter.notebook.keyboard_manager.actions.register(action, action_name, prefix);
 
-        IPython.toolbar.add_buttons_group([action_full_name]);
+        Jupyter.toolbar.add_buttons_group([action_full_name]);
 
         // Register a callback to create a UI element for a cell toolbar.
-        ctb.register_callback('init_cell.is_init_cell', init_cell_ui_callback, 'code');
+        CellToolbar.register_callback('init_cell.is_init_cell', init_cell_ui_callback, 'code');
         // Register a preset of UI elements forming a cell toolbar.
-        ctb.register_preset('Initialisation Cell', ['init_cell.is_init_cell']);
+        CellToolbar.register_preset('Initialisation Cell', ['init_cell.is_init_cell']);
 
         // whenever a (new) kernel  becomes ready, run all initialization cells
         events.on('kernel_ready.Kernel', run_init_cells);


### PR DESCRIPTION
including:
 * making automatic running of initialization cells configurable (fixes #812)
 * never automatically running initialization cells in untrusted notebooks (would cause the outputs to be trusted as though the current user had knowingly executed them, breaking trust model)
