### PR TITLE
CI updates

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 # http://travis-ci.org/#!/ipython-contrib/jupyter_contrib_nbextensions
 language: python
+dist: trusty # required for pandoc>1.9.1
 sudo: false
 addons:
   apt_packages:

--- a/.travis.yml
+++ b/.travis.yml
@@ -33,7 +33,7 @@ matrix:
       python: '3.4'
       env: TOXENV=py27-notebook
     - os: linux
-      python: '3.4'
+      python: '3.3'
       env: TOXENV=py33-notebook
     - os: linux
       python: '3.4'

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,11 @@ matrix:
     # check docs build correctly
     - os: linux
       python: '3.4'
-      env: TOXENV=docs
+      env: TOXENV=docs_build
+    # check docs links
+    - os: linux
+      python: '3.4'
+      env: TOXENV=docs_linkcheck
     # check that conda build/install works
     - os: linux
       python: '3.4'
@@ -64,6 +68,7 @@ matrix:
       env: TOXENV=appveyorartifacts
   allow_failures:
     - env: TOXENV=appveyorartifacts
+    - env: TOXENV=docs_linkcheck
     - env: TOXENV=lint
 env:
   global:

--- a/setup.py
+++ b/setup.py
@@ -116,5 +116,6 @@ if you encounter any problems, and create a new issue if needed!
         ],
     )
 
+
 if __name__ == '__main__':
     main()

--- a/setup.py
+++ b/setup.py
@@ -41,7 +41,7 @@ officially related to the Jupyter development team.
 The maturity of the provided extensions varies, so please check
 `the repository issues page <https://github.com/ipython-contrib/jupyter_contrib_nbextensions/issues>`_
 if you encounter any problems, and create a new issue if needed!
-""",  # noqa
+""",  # noqa: E501
         version='0.2.3',
         author='ipython-contrib and jupyter-contrib developers',
         author_email='jupytercontrib@gmail.com',
@@ -90,14 +90,14 @@ if you encounter any problems, and create a new issue if needed!
         zip_safe=False,
         entry_points={
             'console_scripts': [
-                'jupyter-contrib-nbextension = jupyter_contrib_nbextensions.application:main',  # noqa
+                'jupyter-contrib-nbextension = jupyter_contrib_nbextensions.application:main',  # noqa: E501
             ],
             'jupyter_contrib_core.app.subcommands': [
-                'nbextension = jupyter_contrib_nbextensions.application:jupyter_contrib_core_app_subcommands',  # noqa
+                'nbextension = jupyter_contrib_nbextensions.application:jupyter_contrib_core_app_subcommands',  # noqa: E501
             ],
             'nbconvert.exporters': [
-                'html_toc = jupyter_contrib_nbextensions.nbconvert_support.toc2:TocExporter',  # noqa
-                'html_embed = jupyter_contrib_nbextensions.nbconvert_support.embedhtml:EmbedHTMLExporter',  # noqa
+                'html_toc = jupyter_contrib_nbextensions.nbconvert_support.toc2:TocExporter',  # noqa: E501
+                'html_embed = jupyter_contrib_nbextensions.nbconvert_support.embedhtml:EmbedHTMLExporter',  # noqa: E501
             ],
         },
         scripts=[os.path.join('scripts', p) for p in [

--- a/src/jupyter_contrib_nbextensions/application.py
+++ b/src/jupyter_contrib_nbextensions/application.py
@@ -106,6 +106,7 @@ class BaseContribNbextensionsInstallApp(BaseContribNbextensionsApp):
         return super(BaseContribNbextensionsInstallApp,
                      self).parse_command_line(argv)
 
+
 BaseContribNbextensionsInstallApp.flags['s'] = (
     BaseContribNbextensionsInstallApp.flags['symlink'])
 
@@ -223,11 +224,13 @@ def jupyter_contrib_core_app_subcommands():
     subcommands['nbextensions'] = subcommands['nbextension']
     return subcommands
 
+
 # -----------------------------------------------------------------------------
 # Main
 # -----------------------------------------------------------------------------
 
 main = ContribNbextensionsApp.launch_instance
+
 
 if __name__ == '__main__':
     main()

--- a/src/jupyter_contrib_nbextensions/migrate.py
+++ b/src/jupyter_contrib_nbextensions/migrate.py
@@ -28,7 +28,7 @@ def _migrate_require_paths(logger=None):
 
     mappings = {
         'notebook': [
-            ('config/config_menu/main', 'nbextensions_configurator/config_menu/main'),  # noqa
+            ('config/config_menu/main', 'nbextensions_configurator/config_menu/main'),  # noqa: E501
             ('yapf_ext/yapf_ext', 'code_prettify/code_prettify'),
         ] + [(req, req.split('/', 1)[1]) for req in [
             'codemirrormode/skill/skill',
@@ -138,7 +138,7 @@ def _uninstall_pre_config(logger=None):
     old_postproc_classes = [
         'post_embedhtml.EmbedPostProcessor',
         'jupyter_contrib_nbextensions.nbconvert_support.EmbedPostProcessor',
-        'jupyter_contrib_nbextensions.nbconvert_support.post_embedhtml.EmbedPostProcessor',  # noqa
+        'jupyter_contrib_nbextensions.nbconvert_support.post_embedhtml.EmbedPostProcessor',  # noqa: E501
     ]
     if section.get('postprocessor_class') in old_postproc_classes:
         section.pop('postprocessor_class', None)

--- a/src/jupyter_contrib_nbextensions/nbconvert_support/__init__.py
+++ b/src/jupyter_contrib_nbextensions/nbconvert_support/__init__.py
@@ -2,13 +2,13 @@
 
 import os
 
+from .embedhtml import EmbedHTMLExporter
 from .pp_highlighter import HighlighterPostProcessor, HighlighterPreprocessor
 from .pre_codefolding import CodeFoldingPreprocessor
 from .pre_collapsible_headings import CollapsibleHeadingsPreprocessor
 from .pre_pymarkdown import PyMarkdownPreprocessor
 from .pre_svg2pdf import SVG2PDFPreprocessor
 from .toc2 import TocExporter
-from .embedhtml import EmbedHTMLExporter
 
 __all__ = [
     'CodeFoldingPreprocessor',
@@ -16,8 +16,6 @@ __all__ = [
     'EmbedHTMLExporter',
     'HighlighterPostProcessor',
     'HighlighterPreprocessor',
-    'LenvsHTMLExporter',
-    'LenvsLatexExporter',
     'PyMarkdownPreprocessor',
     'SVG2PDFPreprocessor',
     'templates_directory',

--- a/src/jupyter_contrib_nbextensions/nbconvert_support/pre_codefolding.py
+++ b/src/jupyter_contrib_nbextensions/nbconvert_support/pre_codefolding.py
@@ -13,17 +13,18 @@ class CodeFoldingPreprocessor(Preprocessor):
 
     Folds codecells as displayed in the notebook.
 
-    The preprocessor is installed by default. To enable codefolding with NbConvert,
-    you need to set the configuration parameter `NbConvertApp.codefolding=True`.
+    The preprocessor is installed by default. To enable codefolding with
+    NbConvert, you need to set the configuration parameter
+    `NbConvertApp.codefolding=True`.
     This can be done either in the `jupyter_nbconvert_config.py` file::
 
-        c.NbConvertApp.codefolding=True
+        c.NbConvertApp.codefolding = True
 
     or using a command line parameter when calling NbConvert::
 
         $ jupyter nbconvert --to html --NbConvertApp.codefolding=True mynotebook.ipynb
 
-    """
+    """  # noqa: E501
 
     fold_mark = u'↔'
 
@@ -68,8 +69,8 @@ class CodeFoldingPreprocessor(Preprocessor):
         index : int
             Index of the cell being processed (see base.py)
         """
-        dofolding = self.config.NbConvertApp.get('codefolding', False)
-        if hasattr(cell, "source") and cell.cell_type == "code" and dofolding is True:
+        dofolding = self.config.NbConvertApp.get('codefolding', False) is True
+        if hasattr(cell, 'source') and cell.cell_type == 'code' and dofolding:
             if hasattr(cell['metadata'], 'code_folding'):
                 folded = cell['metadata']['code_folding']
                 if len(folded) > 0:

--- a/src/jupyter_contrib_nbextensions/nbconvert_support/pre_svg2pdf.py
+++ b/src/jupyter_contrib_nbextensions/nbconvert_support/pre_svg2pdf.py
@@ -64,13 +64,17 @@ class SVG2PDFPreprocessor(Preprocessor):
 
     Because LaTeX can't use SVG graphics, they are converted to PDF using
     inkscape_. This preprocessor is for SVG graphics in markdown only. For SVG
-    outputs from codecells, there is already the built-in nbconvert preprocessor
+    outputs from codecells, there is already the built-in nbconvert
+    preprocessor.
+
     Configuration::
 
-        c.Exporter.preprocessors = [ "jupyter_contrib_nbextensions.nbconvert_support.SVG2PDFPreprocessor" ]
+        c.Exporter.preprocessors.append(
+            "jupyter_contrib_nbextensions.nbconvert_support.SVG2PDFPreprocessor"
+        )
 
     .. _inkscape: https://inkscape.org/en
-    """
+    """  # noqa: E501
 
     def _from_format_default(self):
         return 'image/svg+xml'

--- a/src/jupyter_contrib_nbextensions/nbextensions/history/ipy_nb_history_websocket.py
+++ b/src/jupyter_contrib_nbextensions/nbextensions/history/ipy_nb_history_websocket.py
@@ -83,9 +83,11 @@ class WebSocketHandler(tornado.websocket.WebSocketHandler):
                 HISTORY[id] = [x['text']]
                 POSITION[id] = 0
 
+
 application = tornado.web.Application([
     (r"/websocket", WebSocketHandler),
 ])
+
 
 if __name__ == "__main__":
 

--- a/src/jupyter_contrib_nbextensions/nbextensions/htmltools/js_highlight.py
+++ b/src/jupyter_contrib_nbextensions/nbextensions/htmltools/js_highlight.py
@@ -114,6 +114,7 @@ class HtmlHighlightStripper(HTMLParser):
 def rec(reg):
     return re.compile(reg, re.S)
 
+
 pandoc_code_markup_re = rec(r'<pre\s*class="(\w*?)">\s*<code>')
 marked_code_markup_re = rec(r'<pre>\s*<code\s*class="language-(\w*)">')
 pygments_code_markup_re = rec(r'<pre>\s*<code\s*class="hl-(\w*)">')
@@ -158,6 +159,7 @@ class JsHighlightPostProcessor(PostProcessorBase):
 
         return
 
+
 msg = """
 Modify code blocks in nbconvert's HTML output so that the highlighting
 is done in the browser by Javascript.
@@ -187,6 +189,7 @@ def main(path, substitution=None):
     if substitution is not None:
         htmlClassCustomizer.css_substitution = substitution
     htmlClassCustomizer(path)
+
 
 if __name__ == '__main__':
     import sys

--- a/tests/test_exporters.py
+++ b/tests/test_exporters.py
@@ -1,10 +1,11 @@
 # -*- coding: utf-8 -*-
 """Tests for custom exporters."""
 
-from nbconvert.tests.base import TestsBase
-from nbformat import v4, write
 import io
 import os
+
+from nbconvert.tests.base import TestsBase
+from nbformat import v4, write
 
 
 def path_in_data(rel_path):

--- a/tests/test_migrate.py
+++ b/tests/test_migrate.py
@@ -148,7 +148,7 @@ class MigrateTest(TestCase):
         """Check migrate application removes old install correctly."""
         installed_files = self.install_old_pkg()
         # execute the migrate app
-        klass = jupyter_contrib_nbextensions.application.MigrateContribNbextensionsApp  # noqa
+        klass = jupyter_contrib_nbextensions.application.MigrateContribNbextensionsApp  # noqa: E501
         patch_traitlets_app_logs(klass)
         jupyter_contrib_nbextensions.application.main(['migrate'])
         self.check_old_pkg_uninstalled(installed_files)

--- a/tests/test_preprocessors.py
+++ b/tests/test_preprocessors.py
@@ -16,9 +16,10 @@ def path_in_data(rel_path):
 
 
 def export_through_preprocessor(
-        notebook_node, preproc_cls, exporter_class, export_format, customconfig=None):
+        notebook_node, preproc_cls, exporter_class, export_format,
+        customconfig=None):
     """Export a notebook through a given preprocessor."""
-    config=Config(NbConvertApp={'export_format': export_format })
+    config = Config(NbConvertApp={'export_format': export_format})
     if customconfig is not None:
         config.merge(customconfig)
     exporter = exporter_class(
@@ -58,9 +59,10 @@ def test_preprocessor_codefolding():
                                             "    'GR4CX32ZT'"]),
                           metadata={"code_folding": [1]}),
     ])
-    customconfig = Config(NbConvertApp={'codefolding' : True})
+    customconfig = Config(NbConvertApp={'codefolding': True})
     body, resources = export_through_preprocessor(
-        notebook_node, CodeFoldingPreprocessor, RSTExporter, 'rst', customconfig)
+        notebook_node, CodeFoldingPreprocessor, RSTExporter, 'rst',
+        customconfig)
     assert_not_in('AXYZ12AXY', body, 'check firstline fold has worked')
     assert_not_in('GR4CX32ZT', body, 'check function fold has worked')
 

--- a/tests/test_preprocessors.py
+++ b/tests/test_preprocessors.py
@@ -34,7 +34,7 @@ def export_through_preprocessor(
 def test_preprocessor_pymarkdown():
     """Test python markdown preprocessor."""
     # check import shortcut
-    from jupyter_contrib_nbextensions.nbconvert_support import PyMarkdownPreprocessor  # noqa
+    from jupyter_contrib_nbextensions.nbconvert_support import PyMarkdownPreprocessor  # noqa E501
     notebook_node = nbf.new_notebook(cells=[
         nbf.new_code_cell(source="a = 'world'"),
         nbf.new_markdown_cell(source="Hello {{ a }}",
@@ -49,7 +49,7 @@ def test_preprocessor_pymarkdown():
 def test_preprocessor_codefolding():
     """Test codefolding preprocessor."""
     # check import shortcut
-    from jupyter_contrib_nbextensions.nbconvert_support import CodeFoldingPreprocessor  # noqa
+    from jupyter_contrib_nbextensions.nbconvert_support import CodeFoldingPreprocessor  # noqa: E501
     notebook_node = nbf.new_notebook(cells=[
         nbf.new_code_cell(source='\n'.join(["# Codefolding test 1",
                                             "'AXYZ12AXY'"]),
@@ -70,7 +70,7 @@ def test_preprocessor_codefolding():
 def test_preprocessor_svg2pdf():
     """Test svg2pdf preprocessor for markdown cell svg images in latex/pdf."""
     # check import shortcut
-    from jupyter_contrib_nbextensions.nbconvert_support import SVG2PDFPreprocessor  # noqa
+    from jupyter_contrib_nbextensions.nbconvert_support import SVG2PDFPreprocessor  # noqa: E501
     from jupyter_contrib_nbextensions.nbconvert_support.pre_svg2pdf import (
         get_inkscape_executable_path)
     if not get_inkscape_executable_path():
@@ -95,7 +95,7 @@ def test_preprocessor_svg2pdf():
 def test_preprocessor_collapsible_headings():
     """Test collapsible_headings preprocessor."""
     # check import shortcut
-    from jupyter_contrib_nbextensions.nbconvert_support import CollapsibleHeadingsPreprocessor  # noqa
+    from jupyter_contrib_nbextensions.nbconvert_support import CollapsibleHeadingsPreprocessor  # noqa: E501
     cells = []
     for lvl in range(6, 1, -1):
         for collapsed in (True, False):

--- a/tox.ini
+++ b/tox.ini
@@ -65,6 +65,18 @@ commands =
     sphinx-build {posargs:-E} -T -b readthedocs docs/source dist/docs
     sphinx-build {posargs:-E} -T -b linkcheck   docs/source dist/docs
 
+[testenv:docs_build]
+deps =
+    -r{toxinidir}/docs/requirements.txt
+commands =
+    sphinx-build {posargs:-E} -T -b readthedocs docs/source dist/docs
+
+[testenv:docs_linkcheck]
+deps =
+    -r{toxinidir}/docs/requirements.txt
+commands =
+    sphinx-build {posargs:-E} -T -b linkcheck   docs/source dist/docs
+
 [testenv:spell]
 skip_install = true
 setenv =

--- a/tox.ini
+++ b/tox.ini
@@ -17,7 +17,11 @@ basepython =
     py34: {env:TOXPYTHON:python3.4}
     py35: {env:TOXPYTHON:python3.5}
     {spell}: {env:TOXPYTHON:python2.7}
-    {appveyorartifacts,bump,check,clean,codecov,condarecipe,coveralls,docs,lint,report,pypi_build,pypi_upload}: {env:TOXPYTHON:python3.4}
+    {appveyorartifacts,lint,check}: {env:TOXPYTHON:python3.4}
+    {condarecipe}: {env:TOXPYTHON:python3.4}
+    {clean,codecov,coveralls,report}: {env:TOXPYTHON:python3.4}
+    {docs,docs_build,docs_linkcheck}: {env:TOXPYTHON:python3.4}
+    {bump,pypi_build,pypi_upload}: {env:TOXPYTHON:python3.4}
 setenv =
     PYTHONPATH={toxinidir}/tests
     PYTHONUNBUFFERED=yes


### PR DESCRIPTION
* require trusty dist on travis, to avoid complaints about the old 1.9.1 pandoc version provided on precise otherwise
* fix travis py33 python version (typo meant travis was providing 3.4)
* fix linting errors
* make noqa comments for specific errors
* split docs build and linkcheck to allow failures in linkcheck
