### PR TITLE
fix init cell extension bug on trust warning

### DIFF
--- a/src/jupyter_contrib_nbextensions/nbextensions/init_cell/main.js
+++ b/src/jupyter_contrib_nbextensions/nbextensions/init_cell/main.js
@@ -112,7 +112,7 @@ define(function (require, exports, module) {
                     }
                 }
                 if(Jupyter.notebook._fully_loaded){
-                    init_cells_after_notebook_loaded()
+                    init_cells_after_notebook_loaded();
                 }
                 else{
                     events.on('notebook_loaded.Notebook', init_cells_after_notebook_loaded);

--- a/src/jupyter_contrib_nbextensions/nbextensions/init_cell/main.js
+++ b/src/jupyter_contrib_nbextensions/nbextensions/init_cell/main.js
@@ -90,25 +90,34 @@ define(function (require, exports, module) {
                     console.warn(log_prefix, 'Using default options:', options);
                 })
             .then(function () {
-                if (options.run_on_kernel_ready) {
-                    if (!Jupyter.notebook.trusted) {
-                        dialog.modal({
-                            title : 'Initialization cells in untrusted notebook',
-                            body : 'This notebook is not trusted, so initialization cells will not be automatically run on kernel load. You can still run them manually, though.',
-                            buttons: {'OK': {'class' : 'btn-primary'}},
-                            notebook: Jupyter.notebook,
-                            keyboard_manager: Jupyter.keyboard_manager,
-                        });
-                        return;
-                    }
+                function init_cells_after_notebook_loaded(){
+                    if (options.run_on_kernel_ready) {
+                        if (!Jupyter.notebook.trusted) {
+                            dialog.modal({
+                                title : 'Initialization cells in untrusted notebook',
+                                body : 'This notebook is not trusted, so initialization cells will not be automatically run on kernel load. You can still run them manually, though.',
+                                buttons: {'OK': {'class' : 'btn-primary'}},
+                                notebook: Jupyter.notebook,
+                                keyboard_manager: Jupyter.keyboard_manager,
+                            });
+                            return;
+                        }
 
-                    if (Jupyter.notebook && Jupyter.notebook.kernel && Jupyter.notebook.kernel.info_reply.status === 'ok') {
-                        // kernel is already ready
-                        run_init_cells();
+                        if (Jupyter.notebook && Jupyter.notebook.kernel && Jupyter.notebook.kernel.info_reply.status === 'ok') {
+                            // kernel is already ready
+                            run_init_cells();
+                        }
+                        // whenever a (new) kernel  becomes ready, run all initialization cells
+                        events.on('kernel_ready.Kernel', run_init_cells);
                     }
-                    // whenever a (new) kernel  becomes ready, run all initialization cells
-                    events.on('kernel_ready.Kernel', run_init_cells);
                 }
+                if(Jupyter.notebook._fully_loaded){
+                    init_cells_after_notebook_loaded()
+                }
+                else{
+                    events.on('notebook_loaded.Notebook', init_cells_after_notebook_loaded);
+                }
+
             });
     };
 


### PR DESCRIPTION
When load a Jupyter notebook, the trust warning model dialog always displayed and init cell are not executed although I am very sure that the notebook is trusted.
I debugged the script, found that the notebook's `trust` property was not initiated with `null` when checking, as below:

![20170105170321](https://cloud.githubusercontent.com/assets/4335658/21676090/54dcb5a2-d36f-11e6-930c-6e9dd62e9dcf.png)

this is because the init_cell extension is loaded before notebook is fully loaded. I found when the notebook is big or the network is slow, the bug occurs, so I do a check on whether the notebook is loaded, if not, binding an  `notebook_loaded` event to execute the init run.
