### PR TITLE
[code_prettify] add JSON conversion of results from the R kernel

### DIFF
--- a/src/jupyter_contrib_nbextensions/nbextensions/code_prettify/code_prettify.js
+++ b/src/jupyter_contrib_nbextensions/nbextensions/code_prettify/code_prettify.js
@@ -31,8 +31,8 @@ define(function(require, exports, module) {
         },
         "r": {
             "library": "library(formatR)\nlibrary(jsonlite)",
-            "prefix": "cat(paste(tidy_source(text=",
-            "postfix": ")[['text.tidy']], collapse='\n'))"
+            "prefix": "cat(toJSON(paste(tidy_source(text=",
+            "postfix": ", output=FALSE)[['text.tidy']], collapse='\n')))"
         },
         "javascript": {
             "library": "jsbeautify = require(" + "'js-beautify')",

--- a/src/jupyter_contrib_nbextensions/nbextensions/code_prettify/code_prettify.yaml
+++ b/src/jupyter_contrib_nbextensions/nbextensions/code_prettify/code_prettify.yaml
@@ -61,8 +61,8 @@ Parameters:
       },
       "r": {
         "library": "library(formatR)\nlibrary(jsonlite)",
-        "prefix": "cat(paste(tidy_source(text=",
-        "postfix": ")[['text.tidy']], collapse='\n'))"
+        "prefix": "cat(toJSON(paste(tidy_source(text=",
+        "postfix": ", output=FALSE)[['text.tidy']], collapse='\n')))"
       },
       "javascript": {
         "library": "jsbeautify = require('js-beautify')",


### PR DESCRIPTION
I think we forgot a toJSON conversion in the prefix for R kernels. Additionally, I added a `output=FALSE` to avoid output duplication. This fixes it and prettifying works for R language;  