### PR TITLE
[toc2] - always read threshold parameter from system config - address #646

### DIFF
--- a/src/jupyter_contrib_nbextensions/nbextensions/toc2/main.js
+++ b/src/jupyter_contrib_nbextensions/nbextensions/toc2/main.js
@@ -72,6 +72,13 @@ define(["require", "jquery", "base/js/namespace",  'services/config',
             cfg.moveMenuLeft = IPython.notebook.metadata.toc.moveMenuLeft = config.data.toc2.moveMenuLeft; 
         }
       }
+      // and also threshold taken globally as requested in #646 (if it exists, otherwise default)
+      cfg.threshold = IPython.notebook.metadata.toc.threshold = initial_cfg.threshold;
+      if (config.data.toc2) {
+        if (typeof config.data.toc2.threshold !== "undefined") {
+            cfg.threshold = IPython.notebook.metadata.toc.threshold = config.data.toc2.threshold; 
+        }        
+      }
       // create highlights style section in document
       create_additional_css()
       // call callbacks


### PR DESCRIPTION
The threshold parameter is now always read from system config. This allows to change the toc depth through the nbextensions_configurator, even for existing notebooks. Hope that this address #646. 