### PR TITLE
Fixed a typo in AutoScroll's main.js

### DIFF
--- a/src/jupyter_contrib_nbextensions/nbextensions/autoscroll/main.js
+++ b/src/jupyter_contrib_nbextensions/nbextensions/autoscroll/main.js
@@ -123,7 +123,7 @@ define([
 
         config.load();
         $([IPython.events]).on("notebook_loaded.Notebook", function(){
-            initAutosScroll();
+            initAutoScroll();
         });
 
     };


### PR DESCRIPTION
This typo can cause others (e.g. toc2 in a large notebook) not to work.