### PR TITLE
[toc2] Remove MathJax preview in headers and links

### DIFF
--- a/src/jupyter_contrib_nbextensions/nbextensions/toc2/README.md
+++ b/src/jupyter_contrib_nbextensions/nbextensions/toc2/README.md
@@ -79,3 +79,11 @@ This option requires the IPython kernel and is not present with other kernels.
      - Fixed saving issue due to a race condition in loading/writing metadata; see issues [#1882](https://github.com/jupyter/notebook/issues/1882#issuecomment-260671282) and [#762](https://github.com/ipython-contrib/jupyter_contrib_nbextensions/issues/762)
      - As suggested by @dinya in [#791](https://github.com/ipython-contrib/jupyter_contrib_nbextensions/issues/791), added highlighting of the section that contains the currently edited/selected/executing cell. Colors can be customized by changing `.toc-item-highlight-select` and `.toc-item-highlight-execute` classes in css. 
      -[update nov 23]. As suggested by @jcb91, the highlight colors can now be configured via the nbextensions--configurator, instead of changing the css.  
+- @jfbercher, february 2017.
+     - Threshold (number of headings levels in toc)taken globally as requested in #646 (if it exists, otherwise default)
+     - Make toc2 template inherits from nbextensions template, as mentioned in #847
+     - On header/menu/toolbar resize (resize-header.Page event), resize toc2 sidebar  
+     - On 'toggle-all-headers' event from `hide_menubar` extension, resize toc2 sidebar
+     - Remove MathJax preview in headers and links -- addresses (issue 14 in latex_envs)[https://github.com/jfbercher/jupyter_latex_envs/issues/14]
+
+     

--- a/src/jupyter_contrib_nbextensions/nbextensions/toc2/main.js
+++ b/src/jupyter_contrib_nbextensions/nbextensions/toc2/main.js
@@ -72,6 +72,13 @@ define(["require", "jquery", "base/js/namespace",  'services/config',
             cfg.moveMenuLeft = IPython.notebook.metadata.toc.moveMenuLeft = config.data.toc2.moveMenuLeft; 
         }
       }
+      // and also threshold taken globally as requested in #646 (if it exists, otherwise default)
+      cfg.threshold = IPython.notebook.metadata.toc.threshold = initial_cfg.threshold;
+      if (config.data.toc2) {
+        if (typeof config.data.toc2.threshold !== "undefined") {
+            cfg.threshold = IPython.notebook.metadata.toc.threshold = config.data.toc2.threshold; 
+        }        
+      }
       // create highlights style section in document
       create_additional_css()
       // call callbacks

--- a/src/jupyter_contrib_nbextensions/nbextensions/toc2/toc2.js
+++ b/src/jupyter_contrib_nbextensions/nbextensions/toc2/toc2.js
@@ -10,11 +10,23 @@ function incr_lbl(ary, h_idx) { //increment heading label  w/ h_idx (zero based)
     return ary.slice(0, h_idx + 1);
 }
 
+function removeMathJaxPreview(elt) {
+    elt.find("script[type='math/tex']").each(
+        function(i, e) {
+            $(e).replaceWith('$' + $(e).text() + '$')
+        })
+    elt.find("span.MathJax_Preview").remove()
+    elt.find("span.MathJax").remove()
+    return elt
+}
+  
+
 var make_link = function(h, num_lbl) {
     var a = $("<a/>");
     a.attr("href", '#' + h.attr('id'));
     // get the text *excluding* the link text, whatever it may be
     var hclone = h.clone();
+    hclone = removeMathJaxPreview(hclone);
     if (num_lbl) { hclone.prepend(num_lbl); }
     hclone.children().last().remove(); // remove the last child (that is the automatic anchor)
     hclone.find("a[name]").remove(); //remove all named anchors
@@ -40,6 +52,7 @@ var make_link = function(h, num_lbl) {
     a.attr('data-toc-modified-id', h.attr('id'));
     // get the text *excluding* the link text, whatever it may be
     var hclone = h.clone();
+    hclone = removeMathJaxPreview(hclone);
     if( num_lbl ){ hclone.prepend(num_lbl); }
     hclone.children().last().remove(); // remove the last child (that is the automatic anchor)
     hclone.find("a[name]").remove();   //remove all named anchors


### PR DESCRIPTION
This PR addresses an somewhat involved issue for `toc2` and `latex_envs` together; see [latex_envs#14](https://github.com/jfbercher/jupyter_latex_envs/issues/14).  

`toc2` copies the headers into links in order to populate the toc2 widow/sidebar, the table of contents (if enabled) in the notebook, and finally the navigate menu. When `latex_envs` is enabled, it has the capability to keep all equations and environments correctly numbered: each markdown rendering entails the reset of all equations numbers and the recomputation of all math renderings. Maths are stored as a preview in html, with styling, classes, ids, and embedded scripts. When copying the headers into links, these previews are copied as well. The duplication of ids then seems to cause a mess to the whole webpage rendering: maths in the toc window/sidebar is sometimes duplicated, maths can disappear in the toc and/or in the navigation menu. 

The PR remove MathJax previews in headings links  and restore the latex versions, which in turn, is interpreted by Mathjax when needed. 

