### PR TITLE
Fix/limit output2

### DIFF
--- a/src/jupyter_contrib_nbextensions/nbextensions/limit_output/limit-output.yaml
+++ b/src/jupyter_contrib_nbextensions/nbextensions/limit_output/limit-output.yaml
@@ -6,24 +6,24 @@ Icon: icon.png
 Main: main.js
 Compatibility: 4.x
 Parameters:
+- name: limit_output
+  description: Number of characters to limit output to
+  input_type: number
+  default: 10000
+  step: 1
+  min: 0
 - name: limit_stream
-  description: Number of characters to limit output to
-  input_type: number
-  default: 10000
-  step: 1
-  min: 0
+  description: Enable limiting stream messages
+  input_type: checkbox
+  default: true
 - name: limit_execute_result
-  description: Number of characters to limit output to
-  input_type: number
-  default: 10000
-  step: 1
-  min: 0
+  description: Enable limiting execute_result messages
+  input_type: checkbox
+  default: true
 - name: limit_display_data
-  description: Number of characters to limit output to
-  input_type: number
-  default: 10000
-  step: 1
-  min: 0
+  description: Enable limiting display_data messages
+  input_type: checkbox
+  default: false
 - name: limit_output_message
   description: Message to append when output is limited
   input_type: text

--- a/src/jupyter_contrib_nbextensions/nbextensions/limit_output/limit-output.yaml
+++ b/src/jupyter_contrib_nbextensions/nbextensions/limit_output/limit-output.yaml
@@ -6,7 +6,19 @@ Icon: icon.png
 Main: main.js
 Compatibility: 4.x
 Parameters:
-- name: limit_output
+- name: limit_stream
+  description: Number of characters to limit output to
+  input_type: number
+  default: 10000
+  step: 1
+  min: 0
+- name: limit_execute_result
+  description: Number of characters to limit output to
+  input_type: number
+  default: 10000
+  step: 1
+  min: 0
+- name: limit_display_data
   description: Number of characters to limit output to
   input_type: number
   default: 10000
@@ -15,4 +27,4 @@ Parameters:
 - name: limit_output_message
   description: Message to append when output is limited
   input_type: text
-  default: '<b>limit_output extension: Maximum message size of {limit_output_length} exceeded with {output_length} characters</b>'
+  default: '<b>limit_output extension: Maximum message size for {message_type} of {limit_output_length} exceeded with {output_length} characters</b>'

--- a/src/jupyter_contrib_nbextensions/nbextensions/limit_output/main.js
+++ b/src/jupyter_contrib_nbextensions/nbextensions/limit_output/main.js
@@ -14,7 +14,9 @@ define([
     // define default values for config parameters
     var params = {
         // maximum number of characters the output area is allowed to print
-        limit_output : 10000,
+        limit_stream : 10000,
+        limit_execute_result : 10000,
+        limit_display_data : 10000,
         // message to print when output is limited
         limit_output_message : '<b>limit_output extension: Maximum message size of {limit_output_length} exceeded with {output_length} characters</b>'
     };
@@ -37,7 +39,10 @@ define([
     config.loaded.then(function() {
         update_params();
         // sometimes limit_output metadata val can get stored as a string
-        params.limit_output = parseFloat(params.limit_output);
+        //params.limit_output = parseFloat(params.limit_output);
+        params.limit_stream = parseFloat(params.limit_stream);
+        params.limit_execute_result = parseFloat(params.limit_execute_result);
+        params.limit_display_data = parseFloat(params.limit_display_data);
 
         var old_handle_output = oa.OutputArea.prototype.handle_output;
         oa.OutputArea.prototype.handle_output = function (msg) {
@@ -47,7 +52,8 @@ define([
             }
             else {
                 // get MAX_CHARACTERS from cell metadata if present, otherwise param
-                var MAX_CHARACTERS = params.limit_output;
+                //msg.header.msg_type
+                var MAX_CHARACTERS = 10000 ; //params.limit_output;
                 var cell_metadata = this.element.closest('.cell').data('cell').metadata;
                 if (is_finite_number(cell_metadata.limit_output)) {
                     MAX_CHARACTERS = parseFloat(cell_metadata.limit_output);
@@ -95,7 +101,8 @@ define([
                         "exceeded with",  count, "characters. Further output muted."
                     );
                     // allow simple substitutions for output length for quick debugging
-                    var limitmsg = params.limit_output_message.replace("{limit_output_length}", MAX_CHARACTERS)
+                    var limitmsg = params.limit_output_message.replace("{message_type}", msg.header.msg_type)
+                                                              .replace("{limit_output_length}", MAX_CHARACTERS)
                                                               .replace("{output_length}", count);
                     this.append_output({
                         "output_type": "display_data",

--- a/src/jupyter_contrib_nbextensions/nbextensions/limit_output/readme.md
+++ b/src/jupyter_contrib_nbextensions/nbextensions/limit_output/readme.md
@@ -38,12 +38,11 @@ The `limit_output_message` parameter can be formatted to display the
 `limit_output` length and the current `output_length`, using the respective
 replacement fields `{limit_output_length}` and `{output_length}`.
 
+### Parameter Overview
 
-Parameter | Type | Description 
-----------|------|-------------
-limit_output | number | Number of characters to limit output to
-limit_stream | bool   | Enable limiting stream messages
-limit_execute_result | bool | Enable limiting execute_result messages
-limit_display_data | bool | Enable limiting display_data messages
-limit_output_message | string | Message to append when output is limited
+* limit_output - Number of characters to limit output to
+* limit_stream - Enable limiting stream messages
+* limit_execute_result - Enable limiting execute_result messages
+* limit_display_data - Enable limiting display_data messages
+* limit_output_message - Message to append when output is limited
 

--- a/src/jupyter_contrib_nbextensions/nbextensions/limit_output/readme.md
+++ b/src/jupyter_contrib_nbextensions/nbextensions/limit_output/readme.md
@@ -37,3 +37,13 @@ counted, and if either exceeds `limit_output` characters will be truncated to
 The `limit_output_message` parameter can be formatted to display the
 `limit_output` length and the current `output_length`, using the respective
 replacement fields `{limit_output_length}` and `{output_length}`.
+
+
+Parameter | Type | Description 
+----------|------|-------------
+limit_output | number | Number of characters to limit output to
+limit_stream | bool   | Enable limiting stream messages
+limit_execute_result | bool | Enable limiting execute_result messages
+limit_display_data | bool | Enable limiting display_data messages
+limit_output_message | string | Message to append when output is limited
+


### PR DESCRIPTION
Depending on kernel type, limiting different message types is important.
For Python, `stream` type messages are the most common use case.