### PR TITLE
[toc2] Add a parameter to enable/disable cell widening

### DIFF
--- a/src/jupyter_contrib_nbextensions/nbextensions/toc2/README.md
+++ b/src/jupyter_contrib_nbextensions/nbextensions/toc2/README.md
@@ -2,7 +2,7 @@
 
 ## Description and main features
 
-The toc2 extension enables to collect all running headers and display them in a floating window, as a sidebar or with a navigation menu. The extension is also draggable, resizable, collapsable, dockable and features automatic numerotation with unique links ids, and an optional toc cell. Sections of currently selected/edited or running cells are highlighted in the toc. Finally, the toc can preserved when exporting to html.
+The toc2 extension enables to collect all running headers and display them in a floating window, as a sidebar or with a navigation menu. The extension is also draggable, resizable, collapsable, dockable and features automatic numerotation with unique links ids, and an optional toc cell. Sections of currently selected/edited or running cells are highlighted in the toc. Some minor diplay tweaks are also available (moving header tile/menus, windening cells); Finally, the toc can preserved when exporting to html.
 
 #### First demo:
 ![](demo.gif)
@@ -22,10 +22,14 @@ The state of these two toggles is memorized and restored on reload.
 ## Configuration
 The initial configuration can be given using the IPython-contrib nbextensions facility. It includes:
 
-- The toc initial mode (floating or sidebar) 
-- The maximum depth of headers to display on toc (with a default of 6)
-- The state of the toc cell (default: false, ie not present) 
-- The numbering of headers (true by default). 
+- Display Table of Contents as a sidebar (otherwise as a floating window; default: true) 
+- The maximum depth of headers to display on toc (with a default of 4)
+- The state of the toc cell (default: false, ie not present)
+- Add a navigation menu (default: true)
+- Widening the display area to fit the browser window (may be useful with sidebar option; default: true)    
+- The numbering of headers (true by default)
+- Moving header title and menus on the left (default: true)
+- Customization of highlighting the title of currently selected/running sections.  
 
 The differents states and position of the floating window have reasonable defaults and can be modfied per notebook). 
 
@@ -43,6 +47,11 @@ An exporter is also available. It is now possible to export to html with toc by
 ```
 jupyter nbconvert --to html_toc FILE.ipynb 
 ```
+If you also use latex_envs, you can embed both functionalities while exporting with 
+```
+jupyter nbconvert --to html_with_toclenvs FILE.ipynb 
+```
+
 For the first template (toc), the files toc2.js and main.css (originally located in `<python site-packages>/jupyter_contrib_nbextensions/nbextensions/toc2`)
 must reside in the same directory as intended for the html file.
 In the second template, these files are linked to the
@@ -85,5 +94,7 @@ This option requires the IPython kernel and is not present with other kernels.
      - On header/menu/toolbar resize (resize-header.Page event), resize toc2 sidebar  
      - On 'toggle-all-headers' event from `hide_menubar` extension, resize toc2 sidebar
      - Remove MathJax preview in headers and links -- addresses (issue 14 in latex_envs)[https://github.com/jfbercher/jupyter_latex_envs/issues/14]
+     - Added a parameter to enable/disable cell widening (which is useful when sideBar is on) - default is to widen - address #871
+     - Updated README to please @KadeG in #871
 
      

--- a/src/jupyter_contrib_nbextensions/nbextensions/toc2/README.md
+++ b/src/jupyter_contrib_nbextensions/nbextensions/toc2/README.md
@@ -2,7 +2,7 @@
 
 ## Description and main features
 
-The toc2 extension enables to collect all running headers and display them in a floating window, as a sidebar or with a navigation menu. The extension is also draggable, resizable, collapsable, dockable and features automatic numerotation with unique links ids, and an optional toc cell. Sections of currently selected/edited or running cells are highlighted in the toc. Some minor diplay tweaks are also available (moving header tile/menus, windening cells); Finally, the toc can preserved when exporting to html.
+The toc2 extension enables to collect all running headers and display them in a floating window, as a sidebar or with a navigation menu. The extension is also draggable, resizable, collapsable, dockable and features automatic numerotation with unique links ids, and an optional toc cell. Sections of currently selected/edited or running cells are highlighted in the toc. Some minor diplay tweaks are also available (moving header tile/menus, widening cells); Finally, the toc can preserved when exporting to html.
 
 #### First demo:
 ![](demo.gif)

--- a/src/jupyter_contrib_nbextensions/nbextensions/toc2/main.js
+++ b/src/jupyter_contrib_nbextensions/nbextensions/toc2/main.js
@@ -23,6 +23,7 @@ define(["require", "jquery", "base/js/namespace",  'services/config',
              'sideBar':true,
 	           'navigate_menu':true,
              'moveMenuLeft': true,
+             'widenNotebook': false,
              'colors': {'hover_highlight': '#DAA520',
              'selected_highlight': '#FFD700',
              'running_highlight': '#FF0000'}
@@ -61,23 +62,24 @@ define(["require", "jquery", "base/js/namespace",  'services/config',
       cfg = IPython.notebook.metadata.toc = $.extend(true, cfg,
           IPython.notebook.metadata.toc);
       // excepted colors that are taken globally (if defined)
-      cfg.colors = IPython.notebook.metadata.toc.colors = $.extend(true, {}, initial_cfg.colors);      
+      cfg.colors = $.extend(true, {}, initial_cfg.colors);      
       try
          {cfg.colors = IPython.notebook.metadata.toc.colors = $.extend(true, cfg.colors, config.data.toc2.colors);  }
       catch(e) {}
-      // and moveMenuLeft taken globally (if it exists, otherwise default)
+      // and moveMenuLeft, threshold, wideNotebook taken globally (if it exists, otherwise default)
       cfg.moveMenuLeft = IPython.notebook.metadata.toc.moveMenuLeft = initial_cfg.moveMenuLeft;
+      cfg.threshold = IPython.notebook.metadata.toc.threshold = initial_cfg.threshold;
+      cfg.widenNotebook = IPython.notebook.metadata.toc.widenNotebook = initial_cfg.widenNotebook;
       if (config.data.toc2) {
         if (typeof config.data.toc2.moveMenuLeft !== "undefined") {
             cfg.moveMenuLeft = IPython.notebook.metadata.toc.moveMenuLeft = config.data.toc2.moveMenuLeft; 
         }
-      }
-      // and also threshold taken globally as requested in #646 (if it exists, otherwise default)
-      cfg.threshold = IPython.notebook.metadata.toc.threshold = initial_cfg.threshold;
-      if (config.data.toc2) {
         if (typeof config.data.toc2.threshold !== "undefined") {
             cfg.threshold = IPython.notebook.metadata.toc.threshold = config.data.toc2.threshold; 
-        }        
+        }
+        if (typeof config.data.toc2.widenNotebook !== "undefined") {
+            cfg.widenNotebook = IPython.notebook.metadata.toc.widenNotebook = config.data.toc2.widenNotebook; 
+        }
       }
       // create highlights style section in document
       create_additional_css()
@@ -181,7 +183,6 @@ define(["require", "jquery", "base/js/namespace",  'services/config',
       )
   }
 
-
   var toc_init = function() {
       // read configuration, then call toc    
       cfg = read_config(cfg, function() { table_of_contents(cfg, st); }); // called after config is stable           
@@ -207,13 +208,12 @@ define(["require", "jquery", "base/js/namespace",  'services/config',
   }
 
 
-
   var load_ipython_extension = function() {
       load_css(); //console.log("Loading css")
       toc_button(); //console.log("Adding toc_button")
 
       // Wait for the notebook to be fully loaded
-      if (Jupyter.notebook._fully_loaded) {
+      if (Jupyter.notebook !== undefined && Jupyter.notebook._fully_loaded) {
           // this tests if the notebook is fully loaded 
           console.log("[toc2] Notebook fully loaded -- toc2 initialized ")
           toc_init();
@@ -226,7 +226,6 @@ define(["require", "jquery", "base/js/namespace",  'services/config',
       }
 
   };
-
 
 
   return {

--- a/src/jupyter_contrib_nbextensions/nbextensions/toc2/toc2.js
+++ b/src/jupyter_contrib_nbextensions/nbextensions/toc2/toc2.js
@@ -52,7 +52,7 @@ var make_link = function(h, num_lbl) {
     a.attr('data-toc-modified-id', h.attr('id'));
     // get the text *excluding* the link text, whatever it may be
     var hclone = h.clone();
-    hclone = removeMathJaxPreview(hclone);
+
     if( num_lbl ){ hclone.prepend(num_lbl); }
     hclone.children().last().remove(); // remove the last child (that is the automatic anchor)
     hclone.find("a[name]").remove();   //remove all named anchors
@@ -164,7 +164,29 @@ var make_link = function(h, num_lbl) {
       callback && callback();
   }
 
-
+  function setNotebookWidth(cfg, st) {
+    //cfg.widenNotebook  = false; 
+    if (cfg.sideBar) {
+        if ($('#toc-wrapper').is(':visible')) {
+            $('#notebook-container').css('margin-left', $('#toc-wrapper').width() + 30)
+            $('#notebook-container').css('width', $('#notebook').width() - $('#toc-wrapper').width() - 30)
+        } else {
+            if (cfg.widenNotebook) {
+                $('#notebook-container').css('margin-left', 30);
+                $('#notebook-container').css('width', $('#notebook').width() - 30);
+            } else { // original width
+              $("#notebook-container").css({'width':"82%", 'margin-left':'auto'})             
+            }
+        }
+    } else {
+        if (cfg.widenNotebook) {
+            $('#notebook-container').css('margin-left', 30);
+            $('#notebook-container').css('width', $('#notebook').width() - 30);
+        } else { // original width
+            $("#notebook-container").css({'width':"82%", 'margin-left':'auto'})
+        }
+    }
+}
 
   var create_toc_div = function (cfg,st) {
     var toc_wrapper = $('<div id="toc-wrapper"/>')
@@ -287,10 +309,8 @@ var make_link = function(h, num_lbl) {
           if(liveNotebook){
             IPython.notebook.metadata.toc['sideBar']=true;
             IPython.notebook.set_dirty();}
-          //$('#toc-wrapper').css('height','');
           toc_wrapper.removeClass('float-wrapper').addClass('sidebar-wrapper');
-          $('#notebook-container').css('margin-left',$('#toc-wrapper').width()+30);
-          $('#notebook-container').css('width',$('#notebook').width()-$('#toc-wrapper').width()-30);
+          setNotebookWidth(cfg, st)
           var headerVisibleHeight = $('#header').is(':visible') ? $('#header').height() : 0
           ui.position.top = liveNotebook ? headerVisibleHeight : 0;          
           ui.position.left = 0;
@@ -313,8 +333,7 @@ var make_link = function(h, num_lbl) {
           if (st.oldTocHeight==undefined) st.oldTocHeight=Math.max($('#site').height()/2,200)
           $('#toc-wrapper').css('height',st.oldTocHeight);        
           toc_wrapper.removeClass('sidebar-wrapper').addClass('float-wrapper');
-          $('#notebook-container').css('margin-left',30);
-          $('#notebook-container').css('width',$('#notebook').width()-30);   
+          setNotebookWidth(cfg, st)
           $('#toc').css('height', $('#toc-wrapper').height()-$('#toc-header').height()); //redraw at begin of of drag (after resizing height)
                      
         }
@@ -339,8 +358,7 @@ var make_link = function(h, num_lbl) {
     $('#toc-wrapper').resizable({
         resize : function(event,ui){
           if (cfg.sideBar){
-             $('#notebook-container').css('margin-left',$('#toc-wrapper').width()+30)
-             $('#notebook-container').css('width',$('#notebook').width()-$('#toc-wrapper').width()-30)
+             setNotebookWidth(cfg, st)
           }
           else {
             $('#toc').css('height', $('#toc-wrapper').height()-$('#toc-header').height());         
@@ -393,7 +411,6 @@ var make_link = function(h, num_lbl) {
         if (IPython.notebook.metadata.toc['toc_window_display']!==undefined)    { 
             console.log("******Restoring toc display"); 
             $('#toc-wrapper').css('display',IPython.notebook.metadata.toc['toc_window_display'] ? 'block' : 'none');
-            //$('#toc').css('overflow','auto')
         }
       }
     }
@@ -419,8 +436,7 @@ var make_link = function(h, num_lbl) {
         } else {
             if (cfg.toc_window_display) {
               setTimeout(function() {
-                $('#notebook-container').css('width', $('#notebook').width() - $('#toc-wrapper').width() - 30);
-                $('#notebook-container').css('margin-left', $('#toc-wrapper').width() + 30);
+                setNotebookWidth(cfg, st)
                  }, 500)
             }
             setTimeout(function() {
@@ -619,43 +635,20 @@ var table_of_contents = function (cfg,st) {
     $(window).resize(function(){
         $('#toc').css({maxHeight: $(window).height() - 30});
         $('#toc-wrapper').css({maxHeight: $(window).height() - 10});
-
-        if (cfg.sideBar==true) {
-          if ($('#toc-wrapper').css('display')!='block'){
-          $('#notebook-container').css('margin-left',30);
-          $('#notebook-container').css('width',$('#notebook').width()-30);  
-          }  
-          else{
-          $('#notebook-container').css('margin-left',$('#toc-wrapper').width()+30);
-          $('#notebook-container').css('width',$('#notebook').width()-$('#toc-wrapper').width()-30);
-          $('#toc-wrapper').css('height',liveNotebook ? $('#site').height(): $(window).height() - 10);
-          $('#toc-wrapper').css('top', liveNotebook ? $('#header').height() : 0);  
-          }
-        } else{
-          $('#notebook-container').css('margin-left',30);
-          $('#notebook-container').css('width',$('#notebook').width()-30); 
-        }  
+        setNotebookWidth(cfg, st);
     });
 
     $(window).trigger('resize');
 
 };
-    
+  
+
   var toggle_toc = function (cfg,st) {
     // toggle draw (first because of first-click behavior)
     //$("#toc-wrapper").toggle({'complete':function(){
     $("#toc-wrapper").toggle({
-      'progress':function(){  
-        if (cfg.sideBar==true) {
-          if ($('#toc-wrapper').css('display')!='block'){
-          $('#notebook-container').css('margin-left',st.nbcontainer_marginleft);
-          $('#notebook-container').css('width',st.nbcontainer_width);  
-          }  
-          else{
-          $('#notebook-container').css('margin-left',$('#toc-wrapper').width()+30)
-          $('#notebook-container').css('width',$('#notebook').width()-$('#toc-wrapper').width()-30)  
-          }
-        }        
+      'progress':function(){
+        setNotebookWidth(cfg,st);
       },
     'complete': function(){ 
       if(liveNotebook){
@@ -669,6 +662,3 @@ var table_of_contents = function (cfg,st) {
     });
   
   };
-
-//var out=$.ajax({url:"/nbextensions/toc2/toc2.js", async:false})
-//eval(out.responseText)

--- a/src/jupyter_contrib_nbextensions/nbextensions/toc2/toc2.js
+++ b/src/jupyter_contrib_nbextensions/nbextensions/toc2/toc2.js
@@ -45,21 +45,22 @@ var make_link = function(h, num_lbl) {
 };
 
 
-  var make_link_originalid = function (h, num_lbl) {
-    var a = $("<a/>");
-    a.attr("href", '#' + h.attr('saveid'));
-    // add a data attribute so that other code (e.g. collapsible_headings) can use it
-    a.attr('data-toc-modified-id', h.attr('id'));
-    // get the text *excluding* the link text, whatever it may be
-    var hclone = h.clone();
+  var make_link_originalid = function(h, num_lbl) {
+      var a = $("<a/>");
+      a.attr("href", '#' + h.attr('saveid'));
+      // add a data attribute so that other code (e.g. collapsible_headings) can use it
+      a.attr('data-toc-modified-id', h.attr('id'));
+      // get the text *excluding* the link text, whatever it may be
+      var hclone = h.clone();
+      hclone = removeMathJaxPreview(hclone);
+      if (num_lbl) { hclone.prepend(num_lbl); }
+      hclone.children().last().remove(); // remove the last child (that is the automatic anchor)
+      hclone.find("a[name]").remove(); //remove all named anchors
+      a.html(hclone.html());
+      a.on('click', function() { setTimeout(function() { $.ajax() }, 100) }) //workaround for  https://github.com/jupyter/notebook/issues/699
+      return a;
+  }
 
-    if( num_lbl ){ hclone.prepend(num_lbl); }
-    hclone.children().last().remove(); // remove the last child (that is the automatic anchor)
-    hclone.find("a[name]").remove();   //remove all named anchors
-    a.html(hclone.html());
-    a.on('click',function(){setTimeout(function(){ $.ajax()}, 100) }) //workaround for  https://github.com/jupyter/notebook/issues/699
-    return a;
-}
 
   var ol_depth = function (element) {
     // get depth of nested ol

--- a/src/jupyter_contrib_nbextensions/nbextensions/toc2/toc2.yaml
+++ b/src/jupyter_contrib_nbextensions/nbextensions/toc2/toc2.yaml
@@ -27,7 +27,11 @@ Parameters:
 - name: toc2.sideBar
   description: Display Table of Contents as a sidebar (otherwise as a floating window)
   input_type: checkbox
-  default: true  
+  default: true 
+- name: toc2.widenNotebook
+  description: Widen the display area to fit the browser window (may be useful with sidebar option)   
+  input_type: checkbox
+  default: true 
 - name: toc2.navigate_menu
   description: Display Table of Contents as a navigation menu
   input_type: checkbox


### PR DESCRIPTION
This addresses #871. 
A parameter is added to enable/disable cell widening to fit the browser window (parameter is set to false to be consistent with the previous behavior). This works independently of the state of the toc display (sidebar/floating/hidden). Loading of config parameters have been a bit cleaned. Also reworked the code so that everything (I hope)  resizes correctly with the main browser window. 