### PR TITLE
[codemirror_mode_extensions] add new nbextension

### DIFF
--- a/src/jupyter_contrib_nbextensions/nbextensions/codemirror_mode_extensions/codemirror_mode_extensions.yaml
+++ b/src/jupyter_contrib_nbextensions/nbextensions/codemirror_mode_extensions/codemirror_mode_extensions.yaml
@@ -1,0 +1,7 @@
+Type: Jupyter Notebook Extension
+Name: CodeMirror mode extensions
+Description: |
+  Extends some CodeMirror modes with extra features. Currently just adds
+  support for comment/uncomment and folding for octave/MATLAB mode.
+Main: main.js
+Compatibility: 4.x

--- a/src/jupyter_contrib_nbextensions/nbextensions/codemirror_mode_extensions/main.js
+++ b/src/jupyter_contrib_nbextensions/nbextensions/codemirror_mode_extensions/main.js
@@ -1,0 +1,11 @@
+define(['codemirror/lib/codemirror'], function (CodeMirror) {
+    "use strict";
+    return {
+        load_ipython_extension : function () {
+            CodeMirror.extendMode('octave', {
+                lineComment: '%',
+                fold: 'indent',
+            });
+        }
+    };
+});


### PR DESCRIPTION
This is a small nbextension adding an extension to the codemirror octave mode, because I got frustrated while using an octave kernel from metakernel. I've submitted this extension to codemirror & it's been merged, but it won't make it into notebook for a while, so I'm adding it here for now. We could also add similar extensions for other codemirror modes in future