### PR TITLE
[ExecuteTime] new features!

### DIFF
--- a/src/jupyter_contrib_nbextensions/nbextensions/execute_time/ExecuteTime.css
+++ b/src/jupyter_contrib_nbextensions/nbextensions/execute_time/ExecuteTime.css
@@ -4,7 +4,3 @@
     border-top: 1px solid #CFCFCF;
     font-size: 80%;
 }
-
-.timing_area .pull-right {
-	margin-top: 5px;
-}

--- a/src/jupyter_contrib_nbextensions/nbextensions/execute_time/ExecuteTime.js
+++ b/src/jupyter_contrib_nbextensions/nbextensions/execute_time/ExecuteTime.js
@@ -35,6 +35,10 @@ define([
     var options = {
         default_kernel_to_utc: true,
         display_right_aligned: false,
+        highlight: {
+            use: true,
+            color: '#00bb00',
+        },
     };
 
     function patch_CodeCell_get_callbacks () {
@@ -54,8 +58,8 @@ define([
                         }
                     });
                     var timing_area = update_timing_area(cell);
-                    if ($.ui !== undefined) {
-                        timing_area.stop(true, true).show(0).effect('highlight', {color: '#0B0'});
+                    if ($.ui !== undefined && options.highlight.use) {
+                        timing_area.stop(true, true).show(0).effect('highlight', {color: options.highlight_color});
                     }
                 }
                 else {
@@ -226,7 +230,7 @@ define([
 
     function load_jupyter_extension () {
         // try to load jquery-ui
-        if ($.ui === undefined) {
+        if ($.ui === undefined && options.highlight.use) {
             require(['jquery-ui'], function ($) {}, function (err) {
                 // try to load using the older, non-standard name (without hyphen)
                 require(['jqueryui'], function ($) {}, function (err) {

--- a/src/jupyter_contrib_nbextensions/nbextensions/execute_time/ExecuteTime.js
+++ b/src/jupyter_contrib_nbextensions/nbextensions/execute_time/ExecuteTime.js
@@ -34,6 +34,7 @@ define([
     // defaults, overridden by server's config
     var options = {
         default_kernel_to_utc: true,
+        display_in_utc: false,
         display_right_aligned: false,
         highlight: {
             use: true,
@@ -185,6 +186,9 @@ define([
     }
 
     function format_moment (when) {
+        if (options.display_in_utc) {
+            when.utc();
+        }
         return when.fromNow();
     }
 

--- a/src/jupyter_contrib_nbextensions/nbextensions/execute_time/ExecuteTime.js
+++ b/src/jupyter_contrib_nbextensions/nbextensions/execute_time/ExecuteTime.js
@@ -37,7 +37,7 @@ define([
     };
 
     function patch_CodeCell_get_callbacks () {
-        console.log(log_prefix, 'patching CodeCell.prototype.get_callbacks to insert an ExecuteTime shell.reply callback');
+        console.log(log_prefix, 'patching CodeCell.prototype.get_callbacks');
         var old_get_callbacks = CodeCell.prototype.get_callbacks;
         CodeCell.prototype.get_callbacks = function () {
             var callbacks = old_get_callbacks.apply(this, arguments);
@@ -132,10 +132,6 @@ define([
         update_timing_area(cell);
     }
 
-    function zeropad_time (val) {
-        return ('0' + val).slice(-2);
-    }
-
     function humanized_duration (duration_ms, item_count) {
         if (duration_ms < 1000) { // < 1s, show ms directly
             return Math.round(duration_ms) + 'ms';
@@ -190,22 +186,16 @@ define([
 
         var timing_area = cell.element.find('.timing_area');
         if (timing_area.length < 1) {
-            var ia = cell.element.find('.input_area');
-            // var radius = ia.css('border-radius');
-            // ia.css('border-radius', radius + ' ' + radius + ' 0 0');
-
             timing_area = $('<div/>')
                 .addClass('timing_area')
                 .on('dblclick', function (evt) { toggle_timing_display(cell); })
-                .appendTo(ia);
+                .appendTo(cell.element.find('.input_area'));
         }
 
         var msg = '';
         if (cell.metadata.ExecuteTime.end_time) {
             msg = start_time.format('[Last executed] YYYY-MM-DD HH:mm:ss');
             var exec_time = -start_time.diff(cell.metadata.ExecuteTime.end_time);
-            // var exec_time = Math.round(Math.random() * 100000);
-
             if (exec_time >= 0) {
                 msg += ' in ';
                 msg += humanized_duration(exec_time);

--- a/src/jupyter_contrib_nbextensions/nbextensions/execute_time/ExecuteTime.js
+++ b/src/jupyter_contrib_nbextensions/nbextensions/execute_time/ExecuteTime.js
@@ -34,6 +34,7 @@ define([
     // defaults, overridden by server's config
     var options = {
         default_kernel_to_utc: true,
+        display_right_aligned: false,
     };
 
     function patch_CodeCell_get_callbacks () {
@@ -187,7 +188,7 @@ define([
         var timing_area = cell.element.find('.timing_area');
         if (timing_area.length < 1) {
             timing_area = $('<div/>')
-                .addClass('timing_area')
+                .addClass('timing_area' + (options.display_right_aligned ? ' text-right' : ''))
                 .on('dblclick', function (evt) { toggle_timing_display(cell); })
                 .appendTo(cell.element.find('.input_area'));
         }

--- a/src/jupyter_contrib_nbextensions/nbextensions/execute_time/ExecuteTime.js
+++ b/src/jupyter_contrib_nbextensions/nbextensions/execute_time/ExecuteTime.js
@@ -264,17 +264,18 @@ define([
         }, function on_config_load_error (reason) {
             console.warn(log_prefix, 'Using defaults after error loading config:', reason);
         }).then(function do_stuff_with_config () {
-        patch_CodeCell_get_callbacks();
-        events.on('execute.CodeCell', excute_codecell_callback);
 
-        create_menu();
+            patch_CodeCell_get_callbacks();
+            events.on('execute.CodeCell', excute_codecell_callback);
 
-        // add any existing timing info
-        events.on("notebook_loaded.Notebook", update_all_timing_areas);
-        if (Jupyter.notebook !== undefined && Jupyter.notebook._fully_loaded) {
-            // notebook already loaded, so we missed the event, so update all
-            update_all_timing_areas();
-        }
+            create_menu();
+
+            // add any existing timing info
+            events.on("notebook_loaded.Notebook", update_all_timing_areas);
+            if (Jupyter.notebook !== undefined && Jupyter.notebook._fully_loaded) {
+                // notebook already loaded, so we missed the event, so update all
+                update_all_timing_areas();
+            }
 
             // if displaying relative times, update them at intervals
             if (!options.display_absolute_timings) {

--- a/src/jupyter_contrib_nbextensions/nbextensions/execute_time/ExecuteTime.yaml
+++ b/src/jupyter_contrib_nbextensions/nbextensions/execute_time/ExecuteTime.yaml
@@ -7,6 +7,12 @@ Main: ExecuteTime.js
 Compatibility: 4.x
 Parameters:
 
+- name: ExecuteTime.display_in_utc
+  description: |
+    Display times in UTC, rather than in the local timezone set by the browser
+  default: false
+  input_type: checkbox
+
 - name: ExecuteTime.default_kernel_to_utc
   description: |
     For kernel timestamps which do not specify a timezone, assume UTC

--- a/src/jupyter_contrib_nbextensions/nbextensions/execute_time/ExecuteTime.yaml
+++ b/src/jupyter_contrib_nbextensions/nbextensions/execute_time/ExecuteTime.yaml
@@ -5,3 +5,10 @@ Link: readme.md
 Icon: icon.png
 Main: ExecuteTime.js
 Compatibility: 4.x
+Parameters:
+
+- name: ExecuteTime.default_kernel_to_utc
+  description: |
+    For kernel timestamps which do not specify a timezone, assume UTC
+  default: true
+  input_type: checkbox

--- a/src/jupyter_contrib_nbextensions/nbextensions/execute_time/ExecuteTime.yaml
+++ b/src/jupyter_contrib_nbextensions/nbextensions/execute_time/ExecuteTime.yaml
@@ -7,6 +7,29 @@ Main: ExecuteTime.js
 Compatibility: 4.x
 Parameters:
 
+- name: ExecuteTime.display_absolute_timings
+  description: |
+    Display absolute timings for the start time of execution.
+    Setting false will display a relative timestamp like 'a few seconds ago'
+  default: true
+  input_type: checkbox
+
+- name: ExecuteTime.display_absolute_format
+  description: |
+    The format to use when displaying absolute timings (see above)
+  default: 'YYYY-MM-DD HH:mm:ss'
+  input_type: text
+
+- name: ExecuteTime.relative_timing_update_period
+  description: |
+    Seconds to wait between updating the relative timestamps, if using them
+    (see above)
+  default: 10
+  input_type: number
+  step: 1
+  min: 1
+  max: 600
+
 - name: ExecuteTime.display_in_utc
   description: |
     Display times in UTC, rather than in the local timezone set by the browser

--- a/src/jupyter_contrib_nbextensions/nbextensions/execute_time/ExecuteTime.yaml
+++ b/src/jupyter_contrib_nbextensions/nbextensions/execute_time/ExecuteTime.yaml
@@ -18,3 +18,29 @@ Parameters:
     Right-align the text in the timing area under each cell
   default: false
   input_type: checkbox
+
+- name: ExecuteTime.highlight.use
+  description: |
+    Highlight the displayed execution time on completion of execution
+  default: true
+  input_type: checkbox
+
+- name: ExecuteTime.highlight.color
+  description: |
+    Color to use for highlighting the displayed execution time
+  default: '#00BB00'
+  input_type: color
+
+- name: ExecuteTime.template.executed
+  description: |
+    Template for the timing message for executed cells. See readme for
+    replacement tokens.
+  default: 'executed in ${duration}, finished ${end_time}'
+  input_type: text
+
+- name: ExecuteTime.template.queued
+  description: |
+    Template for the timing message for queued cells. See readme for
+    replacement tokens.
+  default: 'execution queued ${start_time}'
+  input_type: text

--- a/src/jupyter_contrib_nbextensions/nbextensions/execute_time/ExecuteTime.yaml
+++ b/src/jupyter_contrib_nbextensions/nbextensions/execute_time/ExecuteTime.yaml
@@ -12,3 +12,9 @@ Parameters:
     For kernel timestamps which do not specify a timezone, assume UTC
   default: true
   input_type: checkbox
+
+- name: ExecuteTime.display_right_aligned
+  description: |
+    Right-align the text in the timing area under each cell
+  default: false
+  input_type: checkbox

--- a/src/jupyter_contrib_nbextensions/nbextensions/execute_time/readme.md
+++ b/src/jupyter_contrib_nbextensions/nbextensions/execute_time/readme.md
@@ -29,8 +29,107 @@ currently shown (hidden).
 ![](execution-timings-menu.png)
 
 
+Options
+-------
+
+The nbextension offers a few options for how to display and interpret
+timestamps.
+Options are stored in the `notebook` section of the server's nbconfig, under
+the key `ExecuteTime`.
+The easiest way to configure these is using the
+[jupyter_nbextensions_configurator](https://github.com/Jupyetr-contrib/jupyter_nbextensions_configurator),
+which if you got this nbextension in the usual way from
+[jupyter_contrib_nbextensions](https://github.com/ipython-contrib/jupyter_contrib_nbextensions),
+should also have been installed.
+
+Alternatively, you can also configure them directly with a few lines of python.
+For example, to alter the displayed message, use relative timestamps,
+and set them to update every 5 seconds, we can use the following python
+snippet:
+
+```python
+from notebook.services.config import ConfigManager
+ConfigManager().update('notebook', {'ExecuteTime': {
+   	'display_absolute_timestamps': False,
+    'relative_timing_update_period': 5,
+    'template': {
+    	'executed': 'started ${start_time}, finished in ${duration}',
+    }
+}})
+```
+
+The available options are:
+
+* `ExecuteTime.display_absolute_timings`: Display absolute timings for the
+  start/end time of execution. Setting this `false` will result in the display
+  of a relative timestamp like 'a few seconds ago' (see the moment.js function
+  [fromNow](https://momentjs.com/docs/#/displaying/fromnow/)
+  for details). Defaults to `true`.
+
+* `ExecuteTime.display_absolute_format`: The format to use when displaying
+  absolute timings (see `ExecuteTime.display_absolute_timings`, above).
+  See the moment.js function
+  [format](https://momentjs.com/docs/#/displaying/format/)
+  for details of the template tokens available.
+  Defaults to `'YYYY-MM-DD HH:mm:ss'`.
+
+* `ExecuteTime.relative_timing_update_period`: Seconds to wait between updating
+  the relative timestamps, if using them (see
+  `ExecuteTime.display_absolute_timings`, above).
+  Defaults to `10`.
+
+* `ExecuteTime.display_in_utc`: Display times in UTC, rather than in the local
+  timezone set by the browser.
+  Defaults to `false`.
+
+* `ExecuteTime.default_kernel_to_utc`: For kernel timestamps which do not
+  specify a timezone, assume UTC.
+  Defaults to `true`.
+
+* `ExecuteTime.display_right_aligned`: Right-align the text in the timing area
+  under each cell.
+  Defaults to `false`.
+
+* `ExecuteTime.highlight.use`: Highlight the displayed execution time on
+  completion of execution.
+  Defaults to `true`.
+
+* `ExecuteTime.highlight.color`: Color to use for highlighting the displayed
+  execution time.
+  Defaults to `'#00BB00'`.
+
+* `ExecuteTime.template.executed`: Template for the timing message for executed
+  cells. See readme for     replacement tokens.
+  Defaults to `'executed in ${duration}, finished ${end_time}'`.
+
+* `ExecuteTime.template.queued`: Template for the timing message for queued
+  cells. The template uses an ES2015-like syntax, but replaces only the exact
+  strings `${start_time}`, plus (if defined) `${end_time}` and `${duration}`.
+  Defaults to `'execution queued ${start_time}'`.
+
+
+
 Limitations
 -----------
+
+
+### timezones
+
+As discussed in
+[ipython-contrib/jupyter_contrib_nbextensions#549](https://github.com/ipython-contrib/jupyter_contrib_nbextensions/issues/549),
+[ipython-contrib/jupyter_contrib_nbextensions#904](https://github.com/ipython-contrib/jupyter_contrib_nbextensions/issues/904),
+and
+[jupyter/jupyter_client#143](https://github.com/jupyter/jupyter_client/issues/143),
+although they are (now) supposed to, Jupyter kernels don't always specify a
+timezone for their timestamps, which can cause problems when the
+[moment.js](http://momentjs.com/)
+library assumes the local timezone, rather than UTC, which is what most kernels
+are actually using.
+To help to address this, see the [options](#Options) above, which can be used
+ to assume UTC for unzoned timestamps.
+
+
+### execution queues
 
 For a reason I don't understand, when multiple cells are queued for execution,
 the kernel doesn't send a reply immediately after finishing executing each


### PR DESCRIPTION
A bunch of new configurable options, including:
 * optional assumption of UTC when kernel tz is unspecified (I think this fixes #904?)
 * optional right-alignment of timing note (replaces #657)
 * optional display of relative timings, with configurable update period
 * configurable message templates
 * highlighting use & color
