### PR TITLE
[CI] temporary fix for travis conda build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -114,9 +114,16 @@ before_install:
   - 'if [[ ${TOXENV} == "condarecipe" ]]; then export PATH="$HOME/miniconda/bin:$PATH"; fi'
   - 'if [[ ${TOXENV} == "condarecipe" ]]; then hash -r; fi'
   - 'if [[ ${TOXENV} == "condarecipe" ]]; then conda config --set always_yes yes --set changeps1 no; fi'
-  - 'if [[ ${TOXENV} == "condarecipe" ]]; then conda update -q conda; fi'
   - 'if [[ ${TOXENV} == "condarecipe" ]]; then conda info -a; fi  # Useful for debugging any issues with conda'
-  - 'if [[ ${TOXENV} == "condarecipe" ]]; then conda install conda-build; fi'
+  # conda 4.3.14 & conda-build 2.1.6,2.1.7 seem to fail with signals TypError on travis.
+  # conda's auto-update strategy also means that installing or updating anything else will cause
+  # conda to attempt to update itself.
+  # Thus instead of running
+  #    conda update conda
+  # we install conda & conda-build together, specifying the versions that we
+  # wish to avoid
+  - 'if [[ ${TOXENV} == "condarecipe" ]]; then conda install "conda!=4.3.14" "conda-build!=2.1.6,!=2.1.7"; fi'
+  - 'if [[ ${TOXENV} == "condarecipe" ]]; then conda info -a; fi  # Useful for debugging any issues with conda'
   - 'if [[ ${TOXENV} == "condarecipe" ]]; then git fetch --unshallow; fi'
 install:
   - pip install tox

--- a/tox.ini
+++ b/tox.ini
@@ -171,8 +171,7 @@ deps =
 ; install of conda itself is handled in travis for CI tests
 whitelist_externals =
     conda
-    echo
 commands =
-    echo 'add conda-forge channel'
-    conda build --channel conda-forge conda.recipe
-    conda install --channel conda-forge --use-local jupyter_contrib_nbextensions
+    conda config --prepend channels conda-forge  # add conda-forge channel at lower priority than defaults
+    conda build conda.recipe
+    conda install --use-local jupyter_contrib_nbextensions


### PR DESCRIPTION
as they cause travis condarecipe build to fail reporting a signal-releated TypeError. This should hopefully be fixed by conda in future, hence the blacklist rather than using versions prior to 4.3.14 and 2.1.6

[skip Appveyor]