### PR TITLE
[dragAndDrop] use markdown syntax instead of html

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.2.5
+current_version = 0.2.6
 commit = True
 message = release {new_version}
 tag = False

--- a/README.md
+++ b/README.md
@@ -237,6 +237,11 @@ Each notebook extension typically has it's own directory containing:
 Changes
 =======
 
+0.2.6
+-----
+
+Fix requirements, which got altered incorrectly as part of the 0.2.5 release.
+
 
 0.2.5
 -----

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -41,9 +41,9 @@ author = 'Jupyter Contrib Team'
 # built documents.
 #
 # The short X.Y version.
-version = '0.2.5'
+version = '0.2.6'
 # The full version, including alpha/beta/rc tags.
-release = '0.2.5'
+release = '0.2.6'
 
 # The suffix(es) of source filenames.
 # You can specify multiple suffix as a list of strings

--- a/setup.py
+++ b/setup.py
@@ -42,14 +42,14 @@ The maturity of the provided extensions varies, so please check
 `the repository issues page <https://github.com/ipython-contrib/jupyter_contrib_nbextensions/issues>`_
 if you encounter any problems, and create a new issue if needed!
 """,  # noqa: E501
-        version='0.2.5',
+        version='0.2.6',
         author='ipython-contrib and jupyter-contrib developers',
         author_email='jupytercontrib@gmail.com',
         url=('https://github.com/'
              'ipython-contrib/jupyter_contrib_nbextensions.git'),
         download_url=('https://github.com/'
                       'ipython-contrib/jupyter_contrib_nbextensions'
-                      '/tarball/0.2.5'),
+                      '/tarball/0.2.6'),
         keywords=['IPython', 'Jupyter', 'notebook'],
         license='BSD',
         platforms=['Any'],
@@ -66,7 +66,7 @@ if you encounter any problems, and create a new issue if needed!
             'jupyter_core',
             'jupyter_highlight_selected_word >=0.0.10',
             'jupyter_latex_envs >=1.3.8',
-            'jupyter_nbextensions_configurator >=0.2.5',
+            'jupyter_nbextensions_configurator >=0.2.4',
             'nbconvert',
             'notebook >=4.0',
             'psutil >=2.2.1',

--- a/src/jupyter_contrib_nbextensions/__init__.py
+++ b/src/jupyter_contrib_nbextensions/__init__.py
@@ -4,7 +4,7 @@ import os
 
 import jupyter_nbextensions_configurator
 
-__version__ = '0.2.5'
+__version__ = '0.2.6'
 
 
 def _jupyter_server_extension_paths():

--- a/src/jupyter_contrib_nbextensions/nbextensions/dragdrop/main.js
+++ b/src/jupyter_contrib_nbextensions/nbextensions/dragdrop/main.js
@@ -78,7 +78,7 @@ define([
         utils.promising_ajax(url, settings).then(
             function on_success (data, status, xhr) {
                 var new_cell = IPython.notebook.insert_cell_below('markdown');
-                var str = '<img  src="' + utils.url_path_join(params.subdirectory, name) + '"/>';
+                var str = '![](' + utils.url_path_join(params.subdirectory, name) + ')';
                 new_cell.set_text(str);
                 new_cell.execute();
             },

--- a/src/jupyter_contrib_nbextensions/nbextensions/dragdrop/readme.md
+++ b/src/jupyter_contrib_nbextensions/nbextensions/dragdrop/readme.md
@@ -20,8 +20,8 @@ Internals
 
 The image will be uploaded to the server into the directory where your notebook resides. This means, the image is not copied into the notebook itself, it will only be linked to. The markdown cell in the notebook will contain this tag:
 
-```html
-<img  src="http://127.0.0.1:8888/notebooks/myimage.png"/>
+```markdown
+![](http://127.0.0.1:8888/notebooks/myimage.png)
 ```
 
 The name of the image will be kept, if the drag&drop operation originates from a file system.

--- a/src/jupyter_contrib_nbextensions/nbextensions/init_cell/main.js
+++ b/src/jupyter_contrib_nbextensions/nbextensions/init_cell/main.js
@@ -70,7 +70,7 @@ define([
         Jupyter.toolbar.add_buttons_group([action_full_name]);
 
         // setup things to run on loading config/notebook
-        Jupyter.notebook.config.loaded()
+        Jupyter.notebook.config.loaded
             .then(function update_options_from_config () {
                 $.extend(true, options, Jupyter.notebook.config[mod_name]);
             }, function (reason) {


### PR DESCRIPTION
As discus in https://github.com/jupyter/nbconvert/issues/552 

> [nbconvert] don't support pdf export from general HTML markup in markdown cells

Thus I think it is a better Idea to use markdown syntax, so this extension stays coherent with the ecosystem. 