### PR TITLE
Restore default codefolding hotkey

### DIFF
--- a/src/jupyter_contrib_nbextensions/nbextensions/codefolding/main.js
+++ b/src/jupyter_contrib_nbextensions/nbextensions/codefolding/main.js
@@ -30,7 +30,7 @@ define([
 
     // define default config parameter values
     var params = {
-        codefolding_hotkey : 'Ctrl-x',
+        codefolding_hotkey : 'Alt-f',
     };
 
     // updates default params with any specified in the server's config


### PR DESCRIPTION
Restore hotkey to `Alt-f`. Fixes issue #926.