### PR TITLE
made it work with 5.0.0.dev again

### DIFF
--- a/src/jupyter_contrib_nbextensions/nbextensions/init_cell/main.js
+++ b/src/jupyter_contrib_nbextensions/nbextensions/init_cell/main.js
@@ -70,7 +70,7 @@ define([
         Jupyter.toolbar.add_buttons_group([action_full_name]);
 
         // setup things to run on loading config/notebook
-        Jupyter.notebook.config.loaded()
+        Jupyter.notebook.config.loaded
             .then(function update_options_from_config () {
                 $.extend(true, options, Jupyter.notebook.config[mod_name]);
             }, function (reason) {


### PR DESCRIPTION
In version `5.0.0.dev` of the notebook `Jupyter.notebook.config.loaded` is not a function anymore, but a promise. By taking away the `()` the extension works with 5.0.0.dev again =)