### PR TITLE
[dragAndDrop] use markdown syntax instead of html

### DIFF
--- a/src/jupyter_contrib_nbextensions/nbextensions/dragdrop/main.js
+++ b/src/jupyter_contrib_nbextensions/nbextensions/dragdrop/main.js
@@ -78,7 +78,7 @@ define([
         utils.promising_ajax(url, settings).then(
             function on_success (data, status, xhr) {
                 var new_cell = IPython.notebook.insert_cell_below('markdown');
-                var str = '<img  src="' + utils.url_path_join(params.subdirectory, name) + '"/>';
+                var str = '![](' + utils.url_path_join(params.subdirectory, name) + ')';
                 new_cell.set_text(str);
                 new_cell.execute();
             },

--- a/src/jupyter_contrib_nbextensions/nbextensions/dragdrop/readme.md
+++ b/src/jupyter_contrib_nbextensions/nbextensions/dragdrop/readme.md
@@ -21,7 +21,7 @@ Internals
 The image will be uploaded to the server into the directory where your notebook resides. This means, the image is not copied into the notebook itself, it will only be linked to. The markdown cell in the notebook will contain this tag:
 
 ```markdown
-![](http://127.0.0.1:8888/notebooks/myimage.png)
+![](myimage.png)
 ```
 
 The name of the image will be kept, if the drag&drop operation originates from a file system.

--- a/src/jupyter_contrib_nbextensions/nbextensions/dragdrop/readme.md
+++ b/src/jupyter_contrib_nbextensions/nbextensions/dragdrop/readme.md
@@ -20,8 +20,8 @@ Internals
 
 The image will be uploaded to the server into the directory where your notebook resides. This means, the image is not copied into the notebook itself, it will only be linked to. The markdown cell in the notebook will contain this tag:
 
-```html
-<img  src="http://127.0.0.1:8888/notebooks/myimage.png"/>
+```markdown
+![](http://127.0.0.1:8888/notebooks/myimage.png)
 ```
 
 The name of the image will be kept, if the drag&drop operation originates from a file system.


### PR DESCRIPTION
same as https://github.com/ipython-contrib/jupyter_contrib_nbextensions/pull/925, without the merge commit into the history

As discus in jupyter/nbconvert#552

[nbconvert] don't support pdf export from general HTML markup in markdown cells
Thus I think it is a better Idea to use markdown syntax, so this extension stays coherent with the ecosystem.