### PR TITLE
[ExecuteTime] honour default_kernel_to_utc for both start and end times

### DIFF
--- a/src/jupyter_contrib_nbextensions/nbextensions/execute_time/ExecuteTime.js
+++ b/src/jupyter_contrib_nbextensions/nbextensions/execute_time/ExecuteTime.js
@@ -61,7 +61,7 @@ define([
                 if (msg.msg_type === 'execute_reply') {
                     $.extend(true, cell.metadata, {
                         ExecuteTime: {
-                            start_time: msg.metadata.started,
+                            start_time: add_utc_offset(msg.metadata.started),
                             end_time: add_utc_offset(msg.header.date),
                         }
                     });


### PR DESCRIPTION
as noted in #933, the setting was only being applied to the end time, which was causing the start and end to be separated by the UTC offset.