### PR TITLE
[collapsible_headings] notebook 5.x uses cell position:relative already

### DIFF
--- a/src/jupyter_contrib_nbextensions/nbextensions/collapsible_headings/collapsible_headings.yaml
+++ b/src/jupyter_contrib_nbextensions/nbextensions/collapsible_headings/collapsible_headings.yaml
@@ -1,5 +1,5 @@
-Type: IPython Notebook Extension
-Compatibility: 4.x
+Type: Jupyter Notebook Extension
+Compatibility: 4.x, 5.x
 Name: Collapsible Headings
 Main: main.js
 Description: "Allows notebook to have collapsible sections, separated by headings"
@@ -71,7 +71,7 @@ Parameters:
   input_type: hotkey
   default: shift-a
 - name: collapsible_headings.shortcuts.insert_below
-  description: Command-mode shortcut to insert a heading cellbelow the selected cell's section
+  description: Command-mode shortcut to insert a heading cell below the selected cell's section
   input_type: hotkey
   default: shift-b
 - name: collapsible_headings.select_reveals

--- a/src/jupyter_contrib_nbextensions/nbextensions/collapsible_headings/main.js
+++ b/src/jupyter_contrib_nbextensions/nbextensions/collapsible_headings/main.js
@@ -529,14 +529,21 @@ define(['jquery', 'require'], function ($, require) {
 	 *  Return a promise which resolves when the Tooltip class methods have
 	 *  been appropriately patched.
 	 *
-	 *  We patch method Tooltip._show to make sure tooltip still ends up in the
-	 *  correct place. We temporarily override the cell's position:relative rule
-	 *  while the tooltip position is calculated & the animation queued, before
-	 *  removing the override again.
+	 *  For notebook 4.x, cells had css position:static, and changing them to
+	 *  relative to get heading brackets working broke the tooltip position
+	 *  calculation. In order to fix this, we patch the 4.x Tooltip._show
+	 *  method to temporarily reapply position:static while the tooltip
+	 *  position is calculated & the animation queued, before revertign to the
+	 *  css-appled position:relative.
+	 *	For notebook 5.x, cells are already position:relative, so the patch is
+	 *  unecessary.
 	 *
 	 *  @return {Promise}
 	 */
 	function patch_Tooltip () {
+		if (Number(Jupyter.version[0]) >= 5) {
+			return;
+		}
 		return new Promise(function (resolve, reject) {
 			require(['notebook/js/tooltip'], function on_success (tooltip) {
 				console.debug(log_prefix, 'patching Tooltip.prototype');

--- a/src/jupyter_contrib_nbextensions/nbextensions/collapsible_headings/main.js
+++ b/src/jupyter_contrib_nbextensions/nbextensions/collapsible_headings/main.js
@@ -542,7 +542,7 @@ define(['jquery', 'require'], function ($, require) {
 	 */
 	function patch_Tooltip () {
 		if (Number(Jupyter.version[0]) >= 5) {
-			return;
+			return Promise.resolve();
 		}
 		return new Promise(function (resolve, reject) {
 			require(['notebook/js/tooltip'], function on_success (tooltip) {


### PR DESCRIPTION
so we don't need to patch tooltip.