### PR TITLE
Add option to indent comments to current indent level

### DIFF
--- a/src/jupyter_contrib_nbextensions/nbextensions/comment-uncomment/comment-uncomment.yaml
+++ b/src/jupyter_contrib_nbextensions/nbextensions/comment-uncomment/comment-uncomment.yaml
@@ -1,5 +1,5 @@
 Type: IPython Notebook Extension
-Compatibility: 3.x, 4.x
+Compatibility: 4.x, 5.x
 Name: Comment/Uncomment Hotkey
 Main: main.js
 Description: add new configurable hotkey binding to toggle comments
@@ -10,3 +10,7 @@ Parameters:
   description: keybinding for toggling comments
   input_type: hotkey
   default: alt-c
+- name: comment_uncomment_indent
+  description: indent comment at current indent level instead at beginning of line
+  default: false
+  input_type: checkbox

--- a/src/jupyter_contrib_nbextensions/nbextensions/comment-uncomment/comment-uncomment.yaml
+++ b/src/jupyter_contrib_nbextensions/nbextensions/comment-uncomment/comment-uncomment.yaml
@@ -11,6 +11,6 @@ Parameters:
   input_type: hotkey
   default: alt-c
 - name: comment_uncomment_indent
-  description: indent comment at current indent level instead at beginning of line
+  description: indent comment at current indent level instead of at beginning of line
   default: false
   input_type: checkbox

--- a/src/jupyter_contrib_nbextensions/nbextensions/comment-uncomment/main.js
+++ b/src/jupyter_contrib_nbextensions/nbextensions/comment-uncomment/main.js
@@ -18,6 +18,7 @@ define([
     // define default config parameter values
     var params = {
         comment_uncomment_keybinding : 'alt-c',
+        comment_uncomment_indent: false,
     };
 
     // updates default params with any specified in the server's config
@@ -55,8 +56,7 @@ define([
 
     var toggle_comment = function() {
         var cm = IPython.notebook.get_selected_cell().code_mirror;
-        var from = cm.getCursor("start"), to = cm.getCursor("end");
-        if (!cm.uncomment(from, to)) cm.lineComment(from, to);
+        cm.toggleComment({ indent: params.comment_uncomment_indent });
         return false;
     };
 

--- a/src/jupyter_contrib_nbextensions/nbextensions/comment-uncomment/readme.md
+++ b/src/jupyter_contrib_nbextensions/nbextensions/comment-uncomment/readme.md
@@ -6,4 +6,6 @@ Adds a new configurable hotkey binding to toggle comments on/off.
 Options
 -------
 
-indent: add comment at current indent level instead at beginning of line
+**comment_uncomment_keybinding**: keybinding for toggling comments (default: Alt-c)
+
+***comment_uncomment_indent***: add comment at current indent level instead of at beginning of line

--- a/src/jupyter_contrib_nbextensions/nbextensions/comment-uncomment/readme.md
+++ b/src/jupyter_contrib_nbextensions/nbextensions/comment-uncomment/readme.md
@@ -2,3 +2,8 @@ Comment/Uncomment
 =================
 
 Adds a new configurable hotkey binding to toggle comments on/off.
+
+Options
+-------
+
+indent: add comment at current indent level instead at beginning of line


### PR DESCRIPTION
Add option do enable indenting comments like in https://github.com/jupyter/notebook/issues/954#issuecomment-292800281
![comment_uncomment](https://cloud.githubusercontent.com/assets/2445216/24839997/4ca8f568-1d65-11e7-9343-f267db6950fa.gif)

