### PR TITLE
Freeze uses cell.metadata.editable to support 4.x and 5.x Jupyter notebooks.

### DIFF
--- a/src/jupyter_contrib_nbextensions/nbextensions/freeze/config.yaml
+++ b/src/jupyter_contrib_nbextensions/nbextensions/freeze/config.yaml
@@ -4,7 +4,7 @@ Description: Freeze cells (forbid editing and executing) or make them read-only
 Link: readme.md
 Icon: icon.png
 Main: main.js
-Compatibility: 4.x
+Compatibility: 4.x, 5.x
 Parameters:
 - name: Freeze.readonly_color
   description: |
@@ -17,3 +17,4 @@ Parameters:
     Color to use for frozen cell
   default: '#f0feff'
   input_type: color
+

--- a/src/jupyter_contrib_nbextensions/nbextensions/freeze/main.js
+++ b/src/jupyter_contrib_nbextensions/nbextensions/freeze/main.js
@@ -57,37 +57,33 @@ define([
             return
         }
 
-        if (cell.metadata.run_control === undefined)
-            cell.metadata.run_control = {};
-
         state = state || 'normal';
-        var new_run_control_values;
         var bg;
+        delete cell.metadata.run_control
         switch (state) {
             case 'normal':
-                new_run_control_values = {
-                    read_only: false,
+                cell.metadata.editable = true;
+                cell.metadata.run_control = {
                     frozen: false
                 };
                 bg = "";
                 break;
             case 'read_only':
-                new_run_control_values = {
-                    read_only: true,
+                cell.metadata.editable = false;
+                cell.metadata.run_control = {
                     frozen: false
                 };
                 bg = options.readonly_color;
                 break;
             case 'frozen':
-                new_run_control_values = {
-                    read_only: true,
+                cell.metadata.editable = false;
+                cell.metadata.run_control = {
                     frozen: true
                 };
                 bg = options.frozen_color;
                 break;
         }
-        $.extend(cell.metadata.run_control, new_run_control_values);
-        cell.code_mirror.setOption('readOnly', cell.metadata.run_control.read_only);
+        cell.code_mirror.setOption('readOnly', !cell.metadata.editable);
         var prompt = cell.element.find('div.input_area');
         prompt.css("background-color", bg);
     }
@@ -125,7 +121,12 @@ define([
                 continue;
             }
             var state = 'normal';
-            if (cell.metadata.run_control != undefined && cell.metadata.run_control.read_only) {
+            // Old metadata format
+            if (cell.metadata.run_control !== undefined && cell.metadata.run_control.read_only) {
+                state = cell.metadata.run_control.frozen ? 'frozen' : 'read_only';
+            }
+            // Jupyter 5.x metadata format
+            if (cell.metadata.run_control !== undefined && cell.metadata.editable !== undefined && !cell.metadata.editable) {
                 state = cell.metadata.run_control.frozen ? 'frozen' : 'read_only';
             }
             set_state(cell, state);

--- a/src/jupyter_contrib_nbextensions/nbextensions/freeze/readme.md
+++ b/src/jupyter_contrib_nbextensions/nbextensions/freeze/readme.md
@@ -20,5 +20,5 @@ The individual cell's state is stored in its metadata and is applied to the cell
 
 ##Internals
 
-The _read-only_ state is stored in the `cell.metadata.run_control.read_only` attribute.
+The _read-only_ state is stored in the `cell.metadata.editable` attribute. Cells are editable by default.
 The _frozen_ state is stored in the `cell.metadata.run_control.frozen`attribute.


### PR DESCRIPTION
Freeze uses cell.metadata.editable instead of cell.metadata.run_control.read_only.
This version reads old format metadata and replaces it by new format metadata (for Freeze).