### PR TITLE
[select_keymap] honour default params as declared in yaml

### DIFF
--- a/src/jupyter_contrib_nbextensions/nbextensions/select_keymap/main.js
+++ b/src/jupyter_contrib_nbextensions/nbextensions/select_keymap/main.js
@@ -28,6 +28,12 @@ define([
         "sublime"
     ];
 
+    /* Values to use for config keys that are note defined in server config */
+    var default_config = {
+        line_wrap: true,
+        local_storage: true,
+    };
+
     var starting_state = {
         extraKeys: {},
         edit_shortcuts: {},
@@ -149,7 +155,10 @@ define([
     });
 
     function get_config(key) {
-        return server_config.data["select_keymap_" + key];
+        if (server_config.data.hasOwnProperty("select_keymap_" + key)) {
+            return server_config.data["select_keymap_" + key];
+        }
+        return default_config[key];
     }
 
     function get_stored_keymap() {


### PR DESCRIPTION
Fixes #960.

Note that this means the as-applied defaults have changed, which may cause confusion switching, but should hopefully be less confusing in the long run.