### PR TITLE
Fix codefolding gutter

### DIFF
--- a/src/jupyter_contrib_nbextensions/nbextensions/codefolding/main.js
+++ b/src/jupyter_contrib_nbextensions/nbextensions/codefolding/main.js
@@ -126,10 +126,11 @@ define([
      * @param cell {codecell.CodeCell} code cell to activate folding gutter
      */
     function activate_cm_folding (cm) {
-        var gutters = cm.getOption('gutters');
-        if ($.inArray("CodeMirror-foldgutter", gutters) < 0) {
-            cm.setOption('gutters', [ gutters , "CodeMirror-foldgutter"]);
-        }
+        var gutters = cm.getOption('gutters').slice();
+        if ( $.inArray("CodeMirror-foldgutter", gutters) < 0) {
+                gutters.push('CodeMirror-foldgutter')
+                cm.setOption('gutters', gutters);
+            }
 
         /* set indent or brace folding */
         var opts = true;

--- a/src/jupyter_contrib_nbextensions/nbextensions/codefolding/main.js
+++ b/src/jupyter_contrib_nbextensions/nbextensions/codefolding/main.js
@@ -128,8 +128,7 @@ define([
     function activate_cm_folding (cm) {
         var gutters = cm.getOption('gutters');
         if ($.inArray("CodeMirror-foldgutter", gutters) < 0) {
-            gutters.push('CodeMirror-foldgutter');
-            cm.setOption('gutters', gutters);
+            cm.setOption('gutters', [ gutters , "CodeMirror-foldgutter"]);
         }
 
         /* set indent or brace folding */


### PR DESCRIPTION
WIP: The gutter won't be added otherwise using notebbok 5.0.0 / Mac / Chrome.

`[ gutters , "CodeMirror-foldgutter"]` results in: `[Array(0), "CodeMirror-foldgutter"]`
 
`gutters.push('CodeMirror-foldgutter');` results in `["CodeMirror-foldgutter"]`
