### PR TITLE
require nbconvert >=4.2

### DIFF
--- a/conda.recipe/meta.yaml
+++ b/conda.recipe/meta.yaml
@@ -27,7 +27,7 @@ requirements:
     - jupyter_highlight_selected_word >=0.0.10
     - jupyter_latex_envs >=1.3.8
     - jupyter_nbextensions_configurator >=0.2.4
-    - nbconvert
+    - nbconvert >=4.2
     - notebook >=4.0
     - psutil >=2.2.1
     - pyyaml

--- a/setup.py
+++ b/setup.py
@@ -67,7 +67,7 @@ if you encounter any problems, and create a new issue if needed!
             'jupyter_highlight_selected_word >=0.0.10',
             'jupyter_latex_envs >=1.3.8',
             'jupyter_nbextensions_configurator >=0.2.4',
-            'nbconvert',
+            'nbconvert >=4.2',
             'notebook >=4.0',
             'psutil >=2.2.1',
             'pyyaml',


### PR DESCRIPTION
nbconvert exporters declared in setuptools entry_points were introduced only in nbconvert 4.2, so we need at least 4.2 for them to work as described in our docs. Potentially relevant to #991, I think. 