### PR TITLE
Fix cell removing after copying of freezed cell

### DIFF
--- a/src/jupyter_contrib_nbextensions/nbextensions/freeze/main.js
+++ b/src/jupyter_contrib_nbextensions/nbextensions/freeze/main.js
@@ -93,7 +93,7 @@ define([
         switch (state) {
             case 'normal':
                 cell.metadata.editable = true;
-				cell.metadata.deletable = true;
+                cell.metadata.deletable = true;
                 if (cell.metadata.run_control !== undefined) {
                     delete cell.metadata.run_control.frozen;
                 }
@@ -101,7 +101,7 @@ define([
                 break;
             case 'read_only':
                 cell.metadata.editable = false;
-				cell.metadata.deletable = false;
+                cell.metadata.deletable = false;
                 if (cell.metadata.run_control !== undefined) {
                     delete cell.metadata.run_control.frozen;
                 }
@@ -109,7 +109,7 @@ define([
                 break;
             case 'frozen':
                 cell.metadata.editable = false;
-				cell.metadata.deletable = false;
+                cell.metadata.deletable = false;
                 $.extend(true, cell.metadata, {run_control: {frozen: true}});
                 bg = options.frozen_color;
                 break;

--- a/src/jupyter_contrib_nbextensions/nbextensions/freeze/main.js
+++ b/src/jupyter_contrib_nbextensions/nbextensions/freeze/main.js
@@ -93,6 +93,7 @@ define([
         switch (state) {
             case 'normal':
                 cell.metadata.editable = true;
+				cell.metadata.deletable = true;
                 if (cell.metadata.run_control !== undefined) {
                     delete cell.metadata.run_control.frozen;
                 }
@@ -100,6 +101,7 @@ define([
                 break;
             case 'read_only':
                 cell.metadata.editable = false;
+				cell.metadata.deletable = false;
                 if (cell.metadata.run_control !== undefined) {
                     delete cell.metadata.run_control.frozen;
                 }
@@ -107,6 +109,7 @@ define([
                 break;
             case 'frozen':
                 cell.metadata.editable = false;
+				cell.metadata.deletable = false;
                 $.extend(true, cell.metadata, {run_control: {frozen: true}});
                 bg = options.frozen_color;
                 break;


### PR DESCRIPTION
If you freeze cell, then copy it, paste, unfreeze and try to delete, you will be unable to do that. I don't know why, but after copying jupyter adds 'deletable' property and in this case it is 'false'. I fixed it with handling of 'deletable' property.