### PR TITLE
[varInspector] Fix #1014 and #1015 - reload on  %reset magic and fix print on python2

### DIFF
--- a/src/jupyter_contrib_nbextensions/nbextensions/varInspector/README.md
+++ b/src/jupyter_contrib_nbextensions/nbextensions/varInspector/README.md
@@ -25,9 +25,7 @@ The initial configuration can be given using the IPython-contrib nbextensions fa
 
 ## Notes
 - The displayed size of variables use the `getsizeof()` python method. This method doesn't work for all types, so the reported size is to be considered with some caution. The extension includes some code to correctly return the size of numpy arrays, pandas Series and DataFrame but the size for some other types may be incorrect. 
-- The extension builds on some
-  [example code](https://github.com/jupyter-widgets/ipywidgets/blob/ffa094e061c899292036049b00ff93e46e8b4691/docs/source/examples/Variable%20Inspector.ipynb)
-  provided by the ipywidgets package (essentially the `_fill` method).
+- The extension builds on some code provided [here](https://github.com/ipython/ipywidgets/blob/master/docs/source/examples/Variable%20Inspector.ipynb)  (essentially the `_fill` method)
 - The extension uses Christian Bach's [table sorter jquery plugin](https://github.com/christianbach/tablesorter). License file is included. 
 
 
@@ -35,3 +33,4 @@ The initial configuration can be given using the IPython-contrib nbextensions fa
 
 - @jfbercher march 22, 2017 -- initial release
 - @jfbercher april 03, 2017 -- multiple kernel support. added support for R kernels.
+- @jfbercher june 30, 2017 -- fixed #1014 (use of `%reset` with IPython kernel) and #1015 printing with python 2 kernel.

--- a/src/jupyter_contrib_nbextensions/nbextensions/varInspector/main.js
+++ b/src/jupyter_contrib_nbextensions/nbextensions/varInspector/main.js
@@ -144,7 +144,9 @@ function html_table(jsonVars) {
 
     function code_exec_callback(msg) {
         var jsonVars = msg.content['text'];
-        $('#varInspector').html(html_table(jsonVars))
+        if (jsonVars == undefined) varInspector_init() 
+        //means that msg.text is undefined, that is var_dic_list was cleared ==> need to retart the enxtesnion
+        else $('#varInspector').html(html_table(jsonVars))
         
         require(['nbextensions/varInspector/jquery.tablesorter.min'],
             function() {

--- a/src/jupyter_contrib_nbextensions/nbextensions/varInspector/main.js
+++ b/src/jupyter_contrib_nbextensions/nbextensions/varInspector/main.js
@@ -144,8 +144,12 @@ function html_table(jsonVars) {
 
     function code_exec_callback(msg) {
         var jsonVars = msg.content['text'];
-        if (jsonVars == undefined) varInspector_init() 
-        //means that msg.text is undefined, that is var_dic_list was cleared ==> need to retart the enxtesnion
+        var notWellDefined = false;
+        if (msg.content.evalue) 
+            notWellDefined = msg.content.evalue == "name 'var_dic_list' is not defined" || 
+        msg.content.evalue.substr(0,28) == "Error in cat(var_dic_list())"
+        //means that var_dic_list was cleared ==> need to retart the extension
+        if (notWellDefined) varInspector_init() 
         else $('#varInspector').html(html_table(jsonVars))
         
         require(['nbextensions/varInspector/jquery.tablesorter.min'],

--- a/src/jupyter_contrib_nbextensions/nbextensions/varInspector/varInspector.yaml
+++ b/src/jupyter_contrib_nbextensions/nbextensions/varInspector/varInspector.yaml
@@ -4,7 +4,7 @@ Description: The Variable Inspector extension collects all defined variables and
 Link: README.md
 Icon: icon.png
 Main: main.js
-Compatibility: 4.x
+Compatibility: 4.x, 5.x
 Parameters:
 - name: varInspector.window_display
   description: Display window at startup

--- a/src/jupyter_contrib_nbextensions/nbextensions/varInspector/var_list.py
+++ b/src/jupyter_contrib_nbextensions/nbextensions/varInspector/var_list.py
@@ -1,11 +1,7 @@
-from __future__ import print_function
-
-import json
 from sys import getsizeof
-
-from IPython import get_ipython
 from IPython.core.magics.namespace import NamespaceMagics
-
+from IPython import get_ipython
+import json
 _nms = NamespaceMagics()
 _Jupyter = get_ipython()
 _nms.shell = _Jupyter.kernel.shell
@@ -24,7 +20,7 @@ def _getsizeof(x):
 
 def var_dic_list():
     types_to_exclude = ['module', 'function', 'builtin_function_or_method',
-                        'instance', '_Feature']
+                        'instance', '_Feature', 'type', 'ufunc']
     values = _nms.who_ls()
     vardic = [{'varName': v, 'varType': type(eval(v)).__name__, 'varSize': _getsizeof(eval(v)), 'varContent': str(eval(v))[:200]} # noqa
     for v in values if (v not in ['_html', '_nms', 'NamespaceMagics', '_Jupyter']) & (type(eval(v)).__name__ not in types_to_exclude)] # noqa 

--- a/src/jupyter_contrib_nbextensions/nbextensions/varInspector/var_list.py
+++ b/src/jupyter_contrib_nbextensions/nbextensions/varInspector/var_list.py
@@ -22,7 +22,7 @@ def var_dic_list():
     types_to_exclude = ['module', 'function', 'builtin_function_or_method',
                         'instance', '_Feature', 'type', 'ufunc']
     values = _nms.who_ls()
-    vardic = [{'varName': v, 'varType': type(eval(v)).__name__, 'varSize': _getsizeof(eval(v)), 'varContent': str(eval(v))[:200]} # noqa
+    vardic = [{'varName': v, 'varType': type(eval(v)).__name__, 'varSize': str(_getsizeof(eval(v))), 'varContent': str(eval(v))[:200]} # noqa
     for v in values if (v not in ['_html', '_nms', 'NamespaceMagics', '_Jupyter']) & (type(eval(v)).__name__ not in types_to_exclude)] # noqa 
     return json.dumps(vardic)
 


### PR DESCRIPTION
- fix #1014 - Actually the `%reset` magic cleared some hidden variables and functions that are used behind the scene by varInspector. Testing the code_exec return message is used to detect this and then the extension is reinitialized (similarly to what happens when restarting the kernel)
- fix for #1015 - removed the import from __future__ solves this
- added some types hidden from listing for python kernels (`type`and `ufunc`)