### PR TITLE
[code_prettify] added support for IPython magics, cf #1018

### DIFF
--- a/src/jupyter_contrib_nbextensions/nbextensions/code_prettify/2to3.yaml
+++ b/src/jupyter_contrib_nbextensions/nbextensions/code_prettify/2to3.yaml
@@ -3,7 +3,7 @@ Name: 2to3 Converter
 Description: Converts python2 code in a notebook's code cell to python3 code
 Link: README_2to3.md
 Main: 2to3.js
-Compatibility: Jupyter (4.x)
+Compatibility: Jupyter 4.x, 5.x
 Parameters:
 
 - name: 2to3.add_toolbar_button

--- a/src/jupyter_contrib_nbextensions/nbextensions/code_prettify/autopep8.yaml
+++ b/src/jupyter_contrib_nbextensions/nbextensions/code_prettify/autopep8.yaml
@@ -3,7 +3,7 @@ Name: Autopep8
 Description: Use kernel-specific code to reformat/prettify the contents of code cells
 Link: README_autopep8.md
 Main: autopep8.js
-Compatibility: Jupyter (4.x)
+Compatibility: Jupyter 4.x, 5.x
 Parameters:
 
 - name: autopep8.add_toolbar_button

--- a/src/jupyter_contrib_nbextensions/nbextensions/code_prettify/code_prettify.js
+++ b/src/jupyter_contrib_nbextensions/nbextensions/code_prettify/code_prettify.js
@@ -25,14 +25,20 @@ define(function(require, exports, module) {
 
     cfg.kernel_config_map = { // map of parameters for supported kernels
         "python": {
-            "library": "import json\nimport yapf.yapflib.yapf_api",
-            "prefix": "print(json.dumps(yapf.yapflib.yapf_api.FormatCode(u",
-            "postfix": ")[0]))"
+            "library": ["import json",
+            "def yapf_reformat(cell_text):", 
+            "    import yapf.yapflib.yapf_api",
+            "    import re",
+            "    cell_text = re.sub('^%', '#%#', cell_text, flags=re.M)",
+            "    reformated_text = yapf.yapflib.yapf_api.FormatCode(cell_text)[0]",
+            "    return re.sub('^#%#', '%', reformated_text, flags=re.M)"].join("\n"),
+            "prefix": "print(json.dumps(yapf_reformat(u",
+            "postfix": ")))"
         },
         "r": {
             "library": "library(formatR)\nlibrary(jsonlite)",
-            "prefix": "cat(paste(tidy_source(text=",
-            "postfix": ")[['text.tidy']], collapse='\n'))"
+            "prefix": "cat(toJSON(paste(tidy_source(text=",
+            "postfix": ", output=FALSE)[['text.tidy']], collapse='\n')))"
         },
         "javascript": {
             "library": "jsbeautify = require(" + "'js-beautify')",

--- a/src/jupyter_contrib_nbextensions/nbextensions/code_prettify/code_prettify.yaml
+++ b/src/jupyter_contrib_nbextensions/nbextensions/code_prettify/code_prettify.yaml
@@ -55,14 +55,14 @@ Parameters:
   default: |
     {
       "python": {
-        "library": "import json\nimport yapf.yapflib.yapf_api",
+        "library": "import json\ndef yapf_reformat(cell_text):\n    import yapf.yapflib.yapf_api\n    import re\n    cell_text = re.sub('^%', '#%#', cell_text, flags=re.M)\n    reformated_text = yapf.yapflib.yapf_api.FormatCode(cell_text)[0]\n    return re.sub('^#%#', '%', reformated_text, flags=re.M)",
         "prefix": "print(json.dumps(yapf.yapflib.yapf_api.FormatCode(u",
         "postfix": ")[0]))"
       },
       "r": {
         "library": "library(formatR)\nlibrary(jsonlite)",
-        "prefix": "cat(paste(tidy_source(text=",
-        "postfix": ")[['text.tidy']], collapse='\n'))"
+        "prefix": "cat(toJSON(paste(tidy_source(text=",
+        "postfix": ", output=FALSE)[['text.tidy']], collapse='\n')))"
       },
       "javascript": {
         "library": "jsbeautify = require('js-beautify')",

--- a/src/jupyter_contrib_nbextensions/nbextensions/code_prettify/code_prettify.yaml
+++ b/src/jupyter_contrib_nbextensions/nbextensions/code_prettify/code_prettify.yaml
@@ -3,7 +3,7 @@ Name: Code prettify
 Description: Use kernel-specific code to reformat/prettify the contents of code cells
 Link: README_code_prettify.md
 Main: code_prettify.js
-Compatibility: Jupyter (4.x)
+Compatibility: Jupyter 4.x, 5.x
 Parameters:
 
 - name: code_prettify.add_toolbar_button


### PR DESCRIPTION
To support IPython magics in python code cells, a function `yapf_reformat` is defined and automatically loaded at initialization as a library. This function takes care of commenting magics before reformatting and uncommenting them after. This should fix #1018. 