### PR TITLE
[ExecuteTime] menu items & options for clearing timing data

### DIFF
--- a/src/jupyter_contrib_nbextensions/nbextensions/execute_time/ExecuteTime.js
+++ b/src/jupyter_contrib_nbextensions/nbextensions/execute_time/ExecuteTime.js
@@ -33,6 +33,7 @@ define([
 
     // defaults, overridden by server's config
     var options = {
+        clear_timings_on_kernel_restart: false,
         default_kernel_to_utc: true,
         display_absolute_format: 'HH:mm:ss YYYY-MM-DD',
         display_absolute_timings: true,
@@ -311,6 +312,12 @@ define([
             if (Jupyter.notebook !== undefined && Jupyter.notebook._fully_loaded) {
                 // notebook already loaded, so we missed the event, so update all
                 update_all_timing_areas();
+            }
+
+            // setup optional clear-data calls
+            if (options.clear_timings_on_kernel_restart) {
+                console.log(log_prefix, 'Binding kernel_restarting.Kernel event to clear timings.');
+                events.on('kernel_restarting.Kernel', clear_timing_data_all);
             }
 
             // if displaying relative times, update them at intervals

--- a/src/jupyter_contrib_nbextensions/nbextensions/execute_time/ExecuteTime.js
+++ b/src/jupyter_contrib_nbextensions/nbextensions/execute_time/ExecuteTime.js
@@ -102,10 +102,10 @@ define([
                         vis = !timing_area.is(':visible');
                     }
                     timing_area.toggle(vis);
-                    return vis;
                 }
             }
         }
+        return vis;
     }
 
     function clear_timing_data (cells) {
@@ -125,7 +125,9 @@ define([
         var timings_menu_item = $('<li/>')
             .addClass('dropdown-submenu')
             .append(
-                $('<a/>').text('Execution Timings')
+                $('<a href="#">')
+                    .text('Execution Timings')
+                    .on('click', function (evt) { evt.preventDefault(); })
             )
             .appendTo($('#cell_menu'));
 
@@ -140,7 +142,6 @@ define([
                     .text('Toggle visibility (selected)')
                     .on('click', function (evt) {
                         evt.preventDefault();
-                        evt.stopPropagation();
                         toggle_timing_display(Jupyter.notebook.get_selected_cells());
                     })
             )
@@ -153,7 +154,6 @@ define([
                     .text('Toggle visibility (all)')
                     .on('click', function (evt) {
                         evt.preventDefault();
-                        evt.stopPropagation();
                         toggle_timing_display(Jupyter.notebook.get_cells());
                     })
             )
@@ -166,7 +166,6 @@ define([
                     .text('Clear (selected)')
                     .on('click', function (evt) {
                         evt.preventDefault();
-                        evt.stopPropagation();
                         clear_timing_data(Jupyter.notebook.get_selected_cells());
                     })
             )
@@ -179,7 +178,6 @@ define([
                     .text('Clear (all)')
                     .on('click', function (evt) {
                         evt.preventDefault();
-                        evt.stopPropagation();
                         clear_timing_data(Jupyter.notebook.get_cells());
                     })
             )

--- a/src/jupyter_contrib_nbextensions/nbextensions/execute_time/ExecuteTime.js
+++ b/src/jupyter_contrib_nbextensions/nbextensions/execute_time/ExecuteTime.js
@@ -45,7 +45,7 @@ define([
             color: '#00bb00',
         },
         relative_timing_update_period: 10,
-        template :{
+        template: {
             executed: 'executed in ${duration}, finished ${end_time}',
             queued: 'execution queued ${start_time}',
         },
@@ -263,7 +263,7 @@ define([
 
         var start_time = moment(cell.metadata.ExecuteTime.start_time),
               end_time = cell.metadata.ExecuteTime.end_time;
-        var msg = options.template[end_time ? 'executed' : 'queued']
+        var msg = options.template[end_time ? 'executed' : 'queued'];
         msg = msg.replace('${start_time}', format_moment(start_time));
         if (end_time) {
             end_time = moment(end_time);

--- a/src/jupyter_contrib_nbextensions/nbextensions/execute_time/ExecuteTime.yaml
+++ b/src/jupyter_contrib_nbextensions/nbextensions/execute_time/ExecuteTime.yaml
@@ -7,6 +7,13 @@ Main: ExecuteTime.js
 Compatibility: 4.x, 5.x
 Parameters:
 
+- name: ExecuteTime.clear_timings_on_clear_output
+  description: |
+    When cells' outputs are cleared, also clear their timing data, e.g. when
+    using the "Kernel > Restart & Clear Output" menu item
+  input_type: checkbox
+  default: false
+
 - name: ExecuteTime.clear_timings_on_kernel_restart
   description: |
     Clear all cells' execution timing data on any kernel restart event

--- a/src/jupyter_contrib_nbextensions/nbextensions/execute_time/ExecuteTime.yaml
+++ b/src/jupyter_contrib_nbextensions/nbextensions/execute_time/ExecuteTime.yaml
@@ -7,6 +7,12 @@ Main: ExecuteTime.js
 Compatibility: 4.x, 5.x
 Parameters:
 
+- name: ExecuteTime.clear_timings_on_kernel_restart
+  description: |
+    Clear all cells' execution timing data on any kernel restart event
+  input_type: checkbox
+  default: false
+
 - name: ExecuteTime.display_absolute_timings
   description: |
     Display absolute timings for the start time of execution.

--- a/src/jupyter_contrib_nbextensions/nbextensions/execute_time/readme.md
+++ b/src/jupyter_contrib_nbextensions/nbextensions/execute_time/readme.md
@@ -60,6 +60,9 @@ ConfigManager().update('notebook', {'ExecuteTime': {
 
 The available options are:
 
+* `ExecuteTime.clear_timings_on_kernel_restart`: Clear all cells' execution
+  timing data on any kernel restart event
+
 * `ExecuteTime.display_absolute_timings`: Display absolute timings for the
   start/end time of execution. Setting this `false` will result in the display
   of a relative timestamp like 'a few seconds ago' (see the moment.js function

--- a/src/jupyter_contrib_nbextensions/nbextensions/execute_time/readme.md
+++ b/src/jupyter_contrib_nbextensions/nbextensions/execute_time/readme.md
@@ -60,6 +60,10 @@ ConfigManager().update('notebook', {'ExecuteTime': {
 
 The available options are:
 
+* `ExecuteTime.clear_timings_on_clear_output`: When cells' outputs are cleared,
+  also clear their timing data, e.g. when using the
+  `Kernel > Restart & Clear Output` menu item
+
 * `ExecuteTime.clear_timings_on_kernel_restart`: Clear all cells' execution
   timing data on any kernel restart event
 


### PR DESCRIPTION
Fixes #1021 (hopefully)

Provides menu items to clear selected/all cells' timing data, along with configurable options to clear timings on kernel restart and/ot when a cell's outputs are cleared.