### PR TITLE
toc2 -- Full url in links | #skip tag to skip headers from being inserted

### DIFF
--- a/src/jupyter_contrib_nbextensions/nbextensions/toc2/README.md
+++ b/src/jupyter_contrib_nbextensions/nbextensions/toc2/README.md
@@ -10,7 +10,12 @@ The toc2 extension enables to collect all running headers and display them in a 
 #### Second demo:
 ![](demo2.gif)
 
-The table of contents is automatically updated when modifications occur in the notebook. The toc window can be moved and resized. It can be docked as a sidebar or dragged from the sidebar into a floating window. The table of contents can be collapsed or the window can be completely hidden. The navigation menu can be enabled/disabled via the nbextensions configuration utility. It can also be resized. The position, dimensions, and states (that is 'collapsed' and 'hidden' states) are remembered (actually stored in the notebook's metadata) and restored on the next session. The toc window also provides two links in its header for further functionalities:
+The table of contents is automatically updated when modifications occur in the notebook. The toc window can be moved and resized. It can be docked as a sidebar or dragged from the sidebar into a floating window. The table of contents can be collapsed or the window can be completely hidden. The navigation menu can be enabled/disabled via the nbextensions configuration utility. It can also be resized. The position, dimensions, and states (that is 'collapsed' and 'hidden' states) are remembered (actually stored in the notebook's metadata) and restored on the next session. Headers can be skipped from being inserted in the toc by adding the html tag "<a class='tocSkip'>" at the end of the header line; eg in 
+```
+## title <a class='tocSkip'>"
+```
+
+The toc window also provides two links in its header for further functionalities:
 
 - the "n" link toggles automatic numerotation of all header lines
 - the "t" link toggles a toc cell in the notebook, which contains the actual table of contents, possibly with the numerotation of the different sections. 

--- a/src/jupyter_contrib_nbextensions/nbextensions/toc2/toc2.js
+++ b/src/jupyter_contrib_nbextensions/nbextensions/toc2/toc2.js
@@ -23,7 +23,8 @@ function removeMathJaxPreview(elt) {
 
 var make_link = function(h, num_lbl) {
     var a = $("<a/>");
-    a.attr("href", '#' + h.attr('id'));
+    a.attr("href", window.location.origin + window.location.pathname + '#' + h.attr('id'));
+    // a.attr("href", h.find('.anchor-link').attr('href'));
     // get the text *excluding* the link text, whatever it may be
     var hclone = h.clone();
     hclone = removeMathJaxPreview(hclone);

--- a/src/jupyter_contrib_nbextensions/nbextensions/toc2/toc2.js
+++ b/src/jupyter_contrib_nbextensions/nbextensions/toc2/toc2.js
@@ -550,9 +550,9 @@ var table_of_contents = function (cfg,st) {
       if (h.id=="Table-of-Contents"){ return; }
       //If h had already a number, remove it
       $(h).find(".toc-item-num").remove();
-      // skip header if tag #skip is present
-      if (h.id.search('#skip') !== -1 ) {
-          $(h).text($(h).text().replace("#skip", ""));
+      // skip header if an html tag with class 'tocSkip' is present
+      // eg in ## title <a class='tocSkip'>
+      if ($(h).find('.tocSkip').length != 0 ) {
           return; }
       var num_str= incr_lbl(lbl_ary,level-1).join('.');// numbered heading labels
       var num_lbl= $("<span/>").addClass("toc-item-num")

--- a/src/jupyter_contrib_nbextensions/nbextensions/toc2/toc2.js
+++ b/src/jupyter_contrib_nbextensions/nbextensions/toc2/toc2.js
@@ -550,6 +550,10 @@ var table_of_contents = function (cfg,st) {
       if (h.id=="Table-of-Contents"){ return; }
       //If h had already a number, remove it
       $(h).find(".toc-item-num").remove();
+      // skip header if tag #skip is present
+      if (h.id.search('#skip') !== -1 ) {
+          $(h).text($(h).text().replace("#skip", ""));
+          return; }
       var num_str= incr_lbl(lbl_ary,level-1).join('.');// numbered heading labels
       var num_lbl= $("<span/>").addClass("toc-item-num")
             .text(num_str).append('&nbsp;').append('&nbsp;');


### PR DESCRIPTION
- #1023 - add full URL in links

- #1027 - add a `#skip` tag for skipping header insertion in toc. Just put 
```
## This is a title #skip
```
and this will be rendered as 
<h2>
This is a title
</h2>
without numbering and will not be inserted in toc. 

