### PR TITLE
[freeze] fix typo/inconsitent state naming

### DIFF
--- a/src/jupyter_contrib_nbextensions/nbextensions/freeze/main.js
+++ b/src/jupyter_contrib_nbextensions/nbextensions/freeze/main.js
@@ -100,6 +100,7 @@ define([
                 bg = "";
                 break;
             case 'read_only':
+            case 'readonly':
                 cell.metadata.editable = false;
                 cell.metadata.deletable = false;
                 if (cell.metadata.run_control !== undefined) {


### PR DESCRIPTION
which was causing readonly cells not to be restored correctly.

Fixes #1008
