### PR TITLE
[toc2] alter ToC cell source to work better with collapsible_headings

### DIFF
--- a/src/jupyter_contrib_nbextensions/nbextensions/toc2/toc2.js
+++ b/src/jupyter_contrib_nbextensions/nbextensions/toc2/toc2.js
@@ -531,7 +531,7 @@ var table_of_contents = function (cfg,st) {
     }
     //process_cell_toc();
     
-    var cell_toc_text = "# Table of Contents\n <p>";
+    var cell_toc_text = " # Table of Contents\n";
     var depth = 1; //var depth = ol_depth(ol);
     var li= ul;//yes, initialize li with ul! 
     var all_headers= $("#notebook").find(":header");


### PR DESCRIPTION
A leading space prevents collapsible_headings from considering the
cell a heading cell.