### PR TITLE
improved running-server checks for install

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,6 +167,11 @@ config-editing operations, or only the file-copy operations:
     - `jupyter_notebook_config.json` to enable the serverextension
       `jupyter_nbextensions_configurator`.
 
+Finally, the `--skip-running-check` option flag is provided in order to allow
+the installation to proceed even if a notebook server appears to be currently
+running (by default, the install will not be performed if a notebook server
+appears to be running).
+
 An analogous `uninstall` command is also provided, to remove all of the
 nbextension files from the jupyter directories.
 

--- a/conda.recipe/meta.yaml
+++ b/conda.recipe/meta.yaml
@@ -29,7 +29,6 @@ requirements:
     - jupyter_nbextensions_configurator >=0.2.4
     - nbconvert >=4.2
     - notebook >=4.0
-    - psutil >=2.2.1
     - pyyaml
     - setuptools
     - tornado

--- a/docs/source/install.md
+++ b/docs/source/install.md
@@ -99,6 +99,11 @@ config-editing operations, or only the file-copy operations:
     - `jupyter_notebook_config.json` to enable the serverextension
       `jupyter_nbextensions_configurator`.
 
+Finally, the `--skip-running-check` option flag is provided in order to allow
+the installation to proceed even if a notebook server appears to be currently
+running (by default, the install will not be performed if a notebook server
+appears to be running).
+
 An analogous `uninstall` command is also provided, to remove all of the
 nbextension files from the jupyter directories.
 

--- a/setup.py
+++ b/setup.py
@@ -69,7 +69,6 @@ if you encounter any problems, and create a new issue if needed!
             'jupyter_nbextensions_configurator >=0.2.4',
             'nbconvert >=4.2',
             'notebook >=4.0',
-            'psutil >=2.2.1',
             'pyyaml',
             'tornado',
             'traitlets >=4.1',

--- a/src/jupyter_contrib_nbextensions/application.py
+++ b/src/jupyter_contrib_nbextensions/application.py
@@ -13,7 +13,8 @@ from traitlets import Bool, Unicode, default
 
 import jupyter_contrib_nbextensions
 from jupyter_contrib_nbextensions.install import (
-    install, toggle_install_config, toggle_install_files, uninstall,
+    install, NotebookRunningError, toggle_install_config, toggle_install_files,
+    uninstall,
 )
 from jupyter_contrib_nbextensions.migrate import migrate
 
@@ -71,6 +72,11 @@ class BaseContribNbextensionsInstallApp(BaseContribNbextensionsApp):
             {'BaseContribNbextensionsInstallApp': {'symlink': True}},
             'Create symlinks for nbextensions instead of copying files'
         ),
+        'skip-running-check': (
+            {'BaseContribNbextensionsInstallApp':
+                {'skip_running_check': True}},
+            'Perform actions even if notebook server(s) are already running'
+        ),
     }
 
     _conflicting_flagsets = [['--user', '--system', '--sys-prefix'], ]
@@ -91,6 +97,9 @@ class BaseContribNbextensionsInstallApp(BaseContribNbextensionsApp):
         '', config=True,
         help='Full path to nbextensions dir '
         '(consider instead using system, sys_prefix, prefix or user option)')
+    skip_running_check = Bool(
+        False, config=True,
+        help='Perform actions even if notebook server(s) are already running')
 
     def parse_command_line(self, argv=None):
         """
@@ -153,15 +162,23 @@ class InstallContribNbextensionsApp(BaseContribNbextensionsInstallApp):
             sys.exit('{} takes no extra arguments'.format(self.name))
         self.log.info('{} {}'.format(self.name, ' '.join(self.argv)))
         kwargs = dict(
-            user=self.user, sys_prefix=self.sys_prefix, logger=self.log)
+            user=self.user, sys_prefix=self.sys_prefix, logger=self.log,
+            skip_running_check=self.skip_running_check)
         kwargs_files = dict(**kwargs)
         kwargs_files.update(dict(
             prefix=self.prefix, nbextensions_dir=self.nbextensions_dir,
             overwrite=self.overwrite, symlink=self.symlink))
-        if not self.only_config:
-            toggle_install_files(self._toggle_value, **kwargs_files)
-        if not self.only_files:
-            toggle_install_config(self._toggle_value, **kwargs)
+        try:
+            if not self.only_config:
+                toggle_install_files(self._toggle_value, **kwargs_files)
+            if not self.only_files:
+                toggle_install_config(self._toggle_value, **kwargs)
+        except NotebookRunningError as err:
+            self.log.warn('Error: %s', err)
+            self.log.info(
+                'To perform actions even while a notebook server is running,'
+                'you may use the flag\n--skip-running-check')
+            raise
 
 
 class UninstallContribNbextensionsApp(InstallContribNbextensionsApp):

--- a/src/jupyter_contrib_nbextensions/install.py
+++ b/src/jupyter_contrib_nbextensions/install.py
@@ -34,9 +34,9 @@ def notebook_is_running(runtime_dir=None):
 
 def toggle_install(install, user=False, sys_prefix=False, overwrite=False,
                    symlink=False, prefix=None, nbextensions_dir=None,
-                   logger=None):
+                   logger=None, skip_running_check=False):
     """Install or remove all jupyter_contrib_nbextensions files & config."""
-    if notebook_is_running():
+    if not skip_running_check and notebook_is_running():
         raise NotebookRunningError(
             'Cannot configure while the Jupyter notebook server is running')
     _check_conflicting_kwargs(user=user, sys_prefix=sys_prefix, prefix=prefix,
@@ -44,16 +44,17 @@ def toggle_install(install, user=False, sys_prefix=False, overwrite=False,
     toggle_install_files(
         install, user=user, sys_prefix=sys_prefix, overwrite=overwrite,
         symlink=symlink, prefix=prefix, nbextensions_dir=nbextensions_dir,
-        logger=logger)
+        logger=logger, skip_running_check=skip_running_check)
     toggle_install_config(
-        install, user=user, sys_prefix=sys_prefix, logger=logger)
+        install, user=user, sys_prefix=sys_prefix, logger=logger,
+        skip_running_check=skip_running_check)
 
 
 def toggle_install_files(install, user=False, sys_prefix=False, logger=None,
                          overwrite=False, symlink=False, prefix=None,
-                         nbextensions_dir=None):
+                         nbextensions_dir=None, skip_running_check=False):
     """Install/remove jupyter_contrib_nbextensions files."""
-    if notebook_is_running():
+    if not skip_running_check and notebook_is_running():
         raise NotebookRunningError(
             'Cannot configure while the Jupyter notebook server is running')
     kwargs = dict(user=user, sys_prefix=sys_prefix, prefix=prefix,
@@ -79,9 +80,10 @@ def toggle_install_files(install, user=False, sys_prefix=False, logger=None,
             nbextensions.uninstall_nbextension_python(mod.__name__, **kwargs)
 
 
-def toggle_install_config(install, user=False, sys_prefix=False, logger=None):
+def toggle_install_config(install, user=False, sys_prefix=False,
+                          skip_running_check=False, logger=None):
     """Install/remove contrib nbextensions to/from jupyter_nbconvert_config."""
-    if notebook_is_running():
+    if not skip_running_check and notebook_is_running():
         raise NotebookRunningError(
             'Cannot configure while the Jupyter notebook server is running')
     _check_conflicting_kwargs(user=user, sys_prefix=sys_prefix)
@@ -146,20 +148,23 @@ def toggle_install_config(install, user=False, sys_prefix=False, logger=None):
 
 
 def install(user=False, sys_prefix=False, prefix=None, nbextensions_dir=None,
-            logger=None, overwrite=False, symlink=False):
+            logger=None, overwrite=False, symlink=False,
+            skip_running_check=False):
     """Install all jupyter_contrib_nbextensions files & config."""
     return toggle_install(
         True, user=user, sys_prefix=sys_prefix, prefix=prefix,
         nbextensions_dir=nbextensions_dir, logger=logger,
-        overwrite=overwrite, symlink=symlink)
+        overwrite=overwrite, symlink=symlink,
+        skip_running_check=skip_running_check)
 
 
 def uninstall(user=False, sys_prefix=False, prefix=None, nbextensions_dir=None,
-              logger=None):
+              logger=None, skip_running_check=False):
     """Uninstall all jupyter_contrib_nbextensions files & config."""
     return toggle_install(
         False, user=user, sys_prefix=sys_prefix, prefix=prefix,
-        nbextensions_dir=nbextensions_dir, logger=logger)
+        nbextensions_dir=nbextensions_dir, logger=logger,
+        skip_running_check=skip_running_check)
 
 # -----------------------------------------------------------------------------
 # Private API


### PR DESCRIPTION
fixes #1043 by obviating the requirement for psutils, relying instead on the (presumably more reliable) method of using notebook-provided functions to check for running servers. Also adds a flat to allow install/uninstall actions without checking for running servers.