### PR TITLE
[various] use Jupyter.notebook.config instance, where appropriate

### DIFF
--- a/src/jupyter_contrib_nbextensions/nbextensions/autosavetime/main.js
+++ b/src/jupyter_contrib_nbextensions/nbextensions/autosavetime/main.js
@@ -1,21 +1,13 @@
 define([
     'jquery',
     'base/js/namespace',
-    'base/js/events',
-    'base/js/utils',
-    'services/config'
+    'base/js/events'
 ], function(
     $,
     IPython,
-    events,
-    utils,
-    configmod
+    events
 ) {
     "use strict";
-
-    // create config object to load parameters
-    var base_url = utils.get_body_data("baseUrl");
-    var config = new configmod.ConfigSection('notebook', {base_url: base_url});
 
     // define default values for config parameters
     var params = {
@@ -26,13 +18,14 @@ define([
 
     // update params with any specified in the server's config file
     var update_params = function() {
+        var config = IPython.notebook.config;
         for (var key in params) {
             if (config.data.hasOwnProperty(key))
                 params[key] = config.data[key];
         }
     };
 
-    config.loaded.then( function() {
+    var initialize = function () {
         update_params();
 
         var si = params.autosavetime_starting_interval;
@@ -76,10 +69,10 @@ define([
                 }
             }
         });
-    });
+    };
 
     var load_ipython_extension = function() {
-        config.load();
+        return IPython.notebook.config.loaded.then(initialize);
     };
 
     return {

--- a/src/jupyter_contrib_nbextensions/nbextensions/autoscroll/main.js
+++ b/src/jupyter_contrib_nbextensions/nbextensions/autoscroll/main.js
@@ -1,16 +1,15 @@
 define([
     'jquery',
     'base/js/namespace',
-    'base/js/utils',
-    'services/config',
+    'base/js/events',
     'notebook/js/outputarea',
     'notebook/js/codecell'
 ], function (
     $,
     IPython,
-    utils,
-    configmod,
-    oa, codecell
+    events,
+    oa,
+    codecell
 ) {
     "use strict";
 
@@ -25,12 +24,9 @@ define([
         autoscroll_show_button : false
     };
 
-    // create config object to load parameters
-    var base_url = utils.get_body_data("baseUrl");
-    var config = new configmod.ConfigSection('notebook', {base_url: base_url});
-
     // update params with any specified in the server's config file
     var update_params = function() {
+        var config = IPython.notebook.config;
         for (var key in params) {
             if (config.data.hasOwnProperty(key))
                 params[key] = config.data[key];
@@ -69,7 +65,7 @@ define([
         initAutoScroll();
     };
 
-    config.loaded.then( function() {
+    var initialize = function() {
         update_params();
 
         var thresholds = [-1, 1, 10, 20, 50, 100, 200, 500, 1000];
@@ -107,7 +103,7 @@ define([
             IPython.toolbar.add_buttons_group([action_full_name]);
         }
         initAutoScroll();
-    });
+    };
 
     var load_ipython_extension = function () {
         var prefix = 'auto';
@@ -121,8 +117,8 @@ define([
 
         action_full_name = IPython.keyboard_manager.actions.register(action, action_name, prefix);
 
-        config.load();
-        $([IPython.events]).on("notebook_loaded.Notebook", function(){
+        IPython.notebook.config.loaded.then(initialize);
+        events.on("notebook_loaded.Notebook", function(){
             initAutoScroll();
         });
 

--- a/src/jupyter_contrib_nbextensions/nbextensions/chrome-clipboard/main.js
+++ b/src/jupyter_contrib_nbextensions/nbextensions/chrome-clipboard/main.js
@@ -2,21 +2,20 @@
 // works with images and notebook cells (MIME-type 'notebook-cell/json')
 
 define([
-    'base/js/namespace',
     'jquery',
-	'base/js/utils',
-    'services/config',
+    'base/js/namespace',
     'base/js/events'
-], function(IPython, $, utils, configmod, events) {
+], function(
+    $,
+    IPython,
+    events
+) {
     "use strict";
     if (window.chrome === undefined) return;
 
     	var params = {
 		subdirectory : '',
 	};
-
-    var base_url = utils.get_body_data("baseUrl");
-    var config = new configmod.ConfigSection('notebook', {base_url: base_url});
 
     /* http://stackoverflow.com/questions/3231459/create-unique-id-with-javascript */
     function uniqueid(){
@@ -58,7 +57,7 @@ define([
             name = uniqueid() + '.' + msg.match(/data:image\/(\S+);/)[1];
             }
         create_dir(path);
-        var url = '//' + location.host + utils.url_path_join(base_url, 'api/contents', path, name);
+        var url = '//' + location.host + utils.url_path_join(IPython.notebook.base_url, 'api/contents', path, name);
 
         var img = msg.replace(/(^\S+,)/, ''); // strip header
         //console.log("send_to_server:", url, img);
@@ -90,10 +89,9 @@ define([
      */
     var load_ipython_extension = function() {
 
-		config.load();
-		config.loaded
+		IPython.notebook.config.loaded
 			.then(function () {
-				$.extend(true, params, config.data.dragdrop); // update params
+				$.extend(true, params, IPython.notebook.config.data.dragdrop); // update params
 				if (params.subdirectory) {
 					console.log('subdir:', params.subdirectory)
 				}

--- a/src/jupyter_contrib_nbextensions/nbextensions/code_prettify/kernel_exec_on_cell.js
+++ b/src/jupyter_contrib_nbextensions/nbextensions/code_prettify/kernel_exec_on_cell.js
@@ -7,8 +7,6 @@ define(function(require, exports, module) {
     var $ = require('jquery');
     var Jupyter = require('base/js/namespace');
     var events = require('base/js/events');
-    var utils = require('base/js/utils');
-    var ConfigSection = require('services/config').ConfigSection;
     var CodeCell = require('notebook/js/codecell').CodeCell;
 
     // this wrapper function allows config & hotkeys to be per-plugin
@@ -286,13 +284,11 @@ define(function(require, exports, module) {
 
     KernelExecOnCells.prototype.initialize_plugin = function() {
         var that = this;
-        var base_url = utils.get_body_data("baseUrl");
-        var conf_section = new ConfigSection('notebook', { base_url: base_url });
         // first, load config
-        conf_section.load()
+        Jupyter.notebook.config.loaded
             // now update default config with that loaded from server
-            .then(function on_success(config_data) {
-                $.extend(true, that.cfg, config_data[that.mod_name]);
+            .then(function on_success() {
+                $.extend(true, that.cfg, Jupyter.notebook.config.data[that.mod_name]);
             }, function on_error(err) {
                 console.warn(that.mod_log_prefix, 'error loading config:', err);
             })

--- a/src/jupyter_contrib_nbextensions/nbextensions/comment-uncomment/main.js
+++ b/src/jupyter_contrib_nbextensions/nbextensions/comment-uncomment/main.js
@@ -2,18 +2,10 @@
 
 define([
     'base/js/namespace',
-    'services/config',
-    'base/js/utils'
 ], function(
-    IPython,
-    configmod,
-    utils
+    IPython
 ) {
     "use strict";
-
-    // create config object to load parameters
-    var base_url = utils.get_body_data("baseUrl");
-    var config = new configmod.ConfigSection('notebook', {base_url: base_url});
 
     // define default config parameter values
     var params = {
@@ -23,6 +15,7 @@ define([
 
     // updates default params with any specified in the server's config
     var update_params = function() {
+        var config = IPython.notebook.config;
         for (var key in params){
             if (config.data.hasOwnProperty(key) ){
                 params[key] = config.data[key];
@@ -30,7 +23,7 @@ define([
         }
     };
 
-    config.loaded.then(function() {
+    var initialize = function () {
         // update defaults
         update_params();
 
@@ -52,7 +45,7 @@ define([
 
         // register keyboard shortcuts with keyboard_manager
         IPython.notebook.keyboard_manager.edit_shortcuts.add_shortcuts(edit_mode_shortcuts);
-    });
+    };
 
     var toggle_comment = function() {
         var cm = IPython.notebook.get_selected_cell().code_mirror;
@@ -61,8 +54,7 @@ define([
     };
 
     var load_ipython_extension = function () {
-        // load config to trigger keybinding registration
-        config.load();
+        return IPython.notebook.config.loaded.then(initialize);
     };
 
     return {

--- a/src/jupyter_contrib_nbextensions/nbextensions/dragdrop/main.js
+++ b/src/jupyter_contrib_nbextensions/nbextensions/dragdrop/main.js
@@ -8,9 +8,8 @@ define([
     'base/js/namespace',
     'jquery',
 	'base/js/utils',
-    'services/config',
     "base/js/events"
-], function(IPython, $, utils, configmod, events) {
+], function(IPython, $, utils, events) {
     "use strict";
 
 	var params = {
@@ -18,7 +17,6 @@ define([
 	};
 
     var base_url = utils.get_body_data("baseUrl");
-    var config = new configmod.ConfigSection('notebook', {base_url: base_url});
 
     /* http://stackoverflow.com/questions/3231459/create-unique-id-with-javascript */
     function uniqueid(){
@@ -193,14 +191,14 @@ define([
 
     var load_jupyter_extension = function() {
         events.on('create.Cell', create_cell);
-		config.load();
-		config.loaded
-			.then(function () {
-				$.extend(true, params, config.data.dragdrop); // update params
-				if (params.subdirectory) {
-					console.log('subdir:', params.subdirectory)
-				}
-			})
+
+        return IPython.notebook.config.loaded.then(function () {
+            // update params
+            $.extend(true, params, IPython.notebook.config.data.dragdrop);
+            if (params.subdirectory) {
+                console.log('[dragdrop] subdir:', params.subdirectory);
+            }
+        });
     };
 
 	return {

--- a/src/jupyter_contrib_nbextensions/nbextensions/gist_it/main.js
+++ b/src/jupyter_contrib_nbextensions/nbextensions/gist_it/main.js
@@ -27,15 +27,11 @@
 define([
     'jquery',
     'base/js/namespace',
-    'base/js/dialog',
-    'base/js/utils',
-    'services/config'
+    'base/js/dialog'
 ], function (
     $,
     Jupyter,
-    dialog,
-    utils,
-    configmod
+    dialog
 ) {
     "use strict";
 
@@ -45,21 +41,18 @@ define([
         gist_it_personal_access_token: '',
     };
 
-    // create config object to load parameters
-    var base_url = utils.get_body_data("baseUrl");
-    var config = new configmod.ConfigSection('notebook', {base_url: base_url});
-
-    config.loaded.then(function() {
+    var initialize = function () {
         update_params();
         Jupyter.toolbar.add_buttons_group([{
             label   : 'Create/Edit Gist of Notebook',
             icon    : 'fa-github',
             callback: show_gist_editor_modal
         }]);
-    });
+    };
 
     // update params with any specified in the server's config file
     var update_params = function() {
+        var config = Jupyter.notebook.config;
         for (var key in params) {
             if (config.data.hasOwnProperty(key))
                 params[key] = config.data[key];
@@ -459,7 +452,7 @@ define([
     };
 
     function load_jupyter_extension () {
-        config.load();
+        return Jupyter.notebook.config.loaded.then(initialize);
     }
 
     return {

--- a/src/jupyter_contrib_nbextensions/nbextensions/help_panel/help_panel.js
+++ b/src/jupyter_contrib_nbextensions/nbextensions/help_panel/help_panel.js
@@ -5,15 +5,11 @@ define([
     'jqueryui',
     'base/js/namespace',
     'base/js/events',
-    'base/js/utils',
-    'services/config'
 ], function (
     require,
     $,
     IPython,
-    events,
-    utils,
-    configmod
+    events
 ) {
     'use strict';
 
@@ -45,19 +41,16 @@ define([
         help_panel_add_toolbar_button: false
     };
 
-    // create config object to load parameters
-    var base_url = utils.get_body_data('baseUrl');
-    var config = new configmod.ConfigSection('notebook', {base_url: base_url});
-
     // update params with any specified in the server's config file
     function update_params () {
+        var config = IPython.notebook.config;
         for (var key in params) {
             if (config.data.hasOwnProperty(key))
                 params[key] = config.data[key];
         }
     }
 
-    config.loaded.then(function() {
+    var initialize = function () {
         update_params();
         if (params.help_panel_add_toolbar_button) {
             IPython.toolbar.add_buttons_group([{
@@ -75,7 +68,7 @@ define([
                 'aria-pressed': 'false'
             });
         }
-    });
+    };
 
     var side_panel_min_rel_width = 10;
     var side_panel_max_rel_width = 90;
@@ -245,7 +238,7 @@ define([
                 href: require.toUrl('./help_panel.css')
             })
         );
-        config.load();
+        return IPython.notebook.config.loaded.then(initialize);
     };
 
     return {

--- a/src/jupyter_contrib_nbextensions/nbextensions/hide_header/main.js
+++ b/src/jupyter_contrib_nbextensions/nbextensions/hide_header/main.js
@@ -1,19 +1,10 @@
 define([
     'base/js/namespace',
-    'services/config',
-    'base/js/utils',
     'base/js/events'
 ], function(
     Jupyter,
-    configmod,
-    utils,
     events
 ) {
-
-    // create config object to load parameters
-    var base_url = utils.get_body_data("baseUrl");
-    var config = new configmod.ConfigSection('notebook', {base_url: base_url});
-
     // define default config parameter values
     var params = {
         header_toggle : 'ctrl-h',
@@ -21,6 +12,7 @@ define([
 
     // updates default params with any specified in the server's config
     var update_params = function() {
+        var config = Jupyter.notebook.config;
         for (var key in params){
             if (config.data.hasOwnProperty(key) ){
                 params[key] = config.data[key];
@@ -28,7 +20,7 @@ define([
         }
     };
 
-    config.loaded.then(function() {
+    var initialize = function () {
         // update defaults
         update_params();
 
@@ -60,12 +52,12 @@ define([
 
         // register keyboard shortcuts with keyboard_manager
         Jupyter.notebook.keyboard_manager.command_shortcuts.add_shortcuts(shortcuts);
-    });
+    };
 
     function load_ipython_extension() {
         $("head").append(
             '<style type="text/css"> .noheader { height: 100% !important }</style>');
-        config.load();
+        return Jupyter.notebook.config.loaded.then(initialize);
     }
 
     return {

--- a/src/jupyter_contrib_nbextensions/nbextensions/hinterland/hinterland.js
+++ b/src/jupyter_contrib_nbextensions/nbextensions/hinterland/hinterland.js
@@ -2,12 +2,11 @@ define(function (require, exports, module) {
 	'use strict';
 
 	var $ = require('jquery');
-	var utils = require('base/js/utils');
+	var Jupyter = require('base/js/namespace');
 	var keyboard = require('base/js/keyboard');
 	var Cell = require('notebook/js/cell').Cell;
 	var CodeCell = require('notebook/js/codecell').CodeCell;
 	var Completer = require('notebook/js/completer').Completer;
-	var ConfigSection = require('services/config').ConfigSection;
 
 	var log_prefix = '[' + module.id + ']';
 
@@ -145,10 +144,9 @@ define(function (require, exports, module) {
 	}
 
 	function load_notebook_extension () {
-		var base_url = utils.get_body_data('baseUrl');
-		var conf_sect = new ConfigSection('notebook', {base_url: base_url});
-		conf_sect.load().then(function on_success (new_conf_data) {
-			$.extend(true, config, new_conf_data.hinterland);
+		
+		Jupyter.notebook.config.loaded.then(function on_success () {
+			$.extend(true, config, Jupyter.notebook.config.data.hinterland);
 			// special defaults:
 			// default include is taken from Completer, rather than the blank
 			if (config.include_regexp === '') {

--- a/src/jupyter_contrib_nbextensions/nbextensions/limit_output/main.js
+++ b/src/jupyter_contrib_nbextensions/nbextensions/limit_output/main.js
@@ -1,15 +1,15 @@
 // Restrict output in a codecell to a maximum length
 
 define([
+    'base/js/namespace',
     'notebook/js/outputarea',
     'notebook/js/codecell',
-    'services/config',
-    'base/js/utils'
-], function(oa, cc, configmod, utils) {
+], function(
+    Jupyter,
+    oa,
+    cc
+) {
     "use strict";
-
-    var base_url = utils.get_body_data("baseUrl");
-    var config = new configmod.ConfigSection('notebook', {base_url: base_url});
 
     // define default values for config parameters
     var params = {
@@ -25,6 +25,7 @@ define([
     // to be called once config is loaded, this updates default config vals
     // with the ones specified by the server's config file
     var update_params = function() {
+        var config = Jupyter.notebook.config;
         for (var key in params) {
             if (config.data.hasOwnProperty(key) ){
                 params[key] = config.data[key];
@@ -37,7 +38,7 @@ define([
         return !isNaN(n) && isFinite(n);
     }
 
-    config.loaded.then(function() {
+    var initialize = function () {
         update_params();
         // sometimes limit_output metadata val can get stored as a string
         params.limit_output = parseFloat(params.limit_output);
@@ -120,10 +121,10 @@ define([
             this.element.data('limit_output_count', 0);
             return old_clear_output.apply(this, arguments);
         };
-    });
+    };
 
     var load_ipython_extension = function() {
-        config.load();
+        return Jupyter.notebook.config.loaded.then(initialize);
     };
 
     return {

--- a/src/jupyter_contrib_nbextensions/nbextensions/nbTranslate/main.js
+++ b/src/jupyter_contrib_nbextensions/nbextensions/nbTranslate/main.js
@@ -8,8 +8,6 @@ define(function(require, exports, module) {
     var $ = require('jquery');
     var Jupyter = require('base/js/namespace');
     var keyboard = require('base/js/keyboard');
-    var utils = require('base/js/utils');
-    var configmod = require('services/config');
     var Cell = require('notebook/js/cell').Cell;
     var CodeCell = require('notebook/js/codecell').CodeCell;
 
@@ -35,15 +33,10 @@ define(function(require, exports, module) {
 
 
     function initialize(conf) {
-
-        // create config object to load parameters
-        var base_url = utils.get_body_data("baseUrl");
-        var config = new configmod.ConfigSection('notebook', { base_url: base_url });
-        config.load();
-        config.loaded.then(function config_loaded_callback() {            
+        Jupyter.notebook.config.loaded.then(function config_loaded_callback() {            
             // config may be specified at system level or at document level.
       // first, update defaults with config loaded from server
-      conf =  $.extend(false, {}, conf, config.data.nbTranslate)
+      conf =  $.extend(false, {}, conf, Jupyter.notebook.config.data.nbTranslate);
       // then update cfg with any found in current notebook metadata
       // and save in nb metadata (then can be modified per document)
       conf = Jupyter.notebook.metadata.nbTranslate = $.extend(false, {}, conf,

--- a/src/jupyter_contrib_nbextensions/nbextensions/printview/main.js
+++ b/src/jupyter_contrib_nbextensions/nbextensions/printview/main.js
@@ -3,22 +3,25 @@
 define([
     'base/js/namespace',
     'jquery',
-    'services/config',
     'base/js/events',
     'base/js/utils'
-], function(IPython, $, configmod, events, utils) {
+], function(
+    IPython,
+    $,
+    events,
+    utils
+) {
     "use strict";
 
     var nbconvert_options = '--to html';
     var extension = '.html';
 	var open_tab = true;
-    var base_url = utils.get_body_data("baseUrl");
-    var config = new configmod.ConfigSection('notebook', {base_url: base_url});
 
     /**
      * Get option from config
      */
-    config.loaded.then(function() {
+    var initialize = function () {
+        var config = IPython.notebook.config;
         if (config.data.hasOwnProperty('printview_nbconvert_options') ) {
             nbconvert_options = config.data.printview_nbconvert_options;
             if (nbconvert_options.search('pdf') > 0) extension = '.pdf';
@@ -29,7 +32,7 @@ define([
                 open_tab = config.data.printview_open_tab;
             }
         }
-    });
+    };
 
     /**
      * Call nbconvert using the current notebook server profile
@@ -56,7 +59,6 @@ define([
 	};
 
 	var load_ipython_extension = function() {
-        config.load();
 		IPython.toolbar.add_buttons_group([
 			{
 				id: 'doPrintView',
@@ -65,6 +67,7 @@ define([
 				callback: nbconvertPrintView
 			}
 		]);
+        return IPython.notebook.config.loaded.then(initialize);
 	};
 
 	return {

--- a/src/jupyter_contrib_nbextensions/nbextensions/scroll_down/main.js
+++ b/src/jupyter_contrib_nbextensions/nbextensions/scroll_down/main.js
@@ -1,29 +1,24 @@
 define([
+    'jquery',
     'base/js/namespace',
-    'services/config',
-    'base/js/utils',
-    'jquery'
-], function (Jupyter,
-             configmod,
-             utils,
-             $) {
+], function (
+    $,
+    Jupyter
+) {
     'use strict';
-
-    var base_url = utils.get_body_data('baseUrl');
-    var config = new configmod.ConfigSection('notebook', {base_url: base_url});
 
     var params = {
         scrollDownIsEnabled: false
     };
 
-    config.loaded.then(function () {
-        $.extend(true, params, config.data);
+    var initialize = function () {
+        $.extend(true, params, Jupyter.notebook.config.data);
         setButtonColor();
-    });
+    };
 
     function toggleScrollDown() {
         params.scrollDownIsEnabled = !params.scrollDownIsEnabled;
-        config.update(params);
+        Jupyter.notebook.config.update(params);
         setButtonColor();
     }
 
@@ -53,11 +48,11 @@ define([
             }, 0);
         });
 
-        config.load();
+        return Jupyter.notebook.config.loaded.then(initialize);
     }
 
     return {
         load_jupyter_extension: load_extension,
         load_ipython_extension: load_extension
-    }
+    };
 });

--- a/src/jupyter_contrib_nbextensions/nbextensions/select_keymap/main.js
+++ b/src/jupyter_contrib_nbextensions/nbextensions/select_keymap/main.js
@@ -2,9 +2,7 @@
 
 define([
     "base/js/namespace",
-    "base/js/utils",
     "notebook/js/cell",
-    "services/config",
     "codemirror/lib/codemirror",
     "codemirror/keymap/emacs",
     "codemirror/keymap/vim",
@@ -16,7 +14,12 @@ define([
     "codemirror/addon/edit/matchbrackets",
     "codemirror/addon/search/searchcursor",
     "codemirror/addon/search/search",
-], function(Jupyter, utils, Cell, configmod, CodeMirror) {
+], function(
+    Jupyter,
+    Cell,
+    CodeMirror
+    // other stuff is loaded, but not used
+) {
     "use_strict";
 
     var previous_mode = "";
@@ -140,19 +143,13 @@ define([
         CodeMirror.defineExtension("openDialog", _this.openDialog);
     }
 
-    var base_url = utils.get_body_data("baseUrl");
-    var server_config = new configmod.ConfigSection("notebook", {
-        base_url: base_url
-    });
-
-    server_config.load();
-
+    var server_config = Jupyter.notebook.config;
     // make sure config is loaded before making initial changes
-    server_config.loaded.then(function() {
+    var initialize = function () {
         save_starting_state();
         // initialize last stored value or default
         switch_keymap(get_stored_keymap());
-    });
+    };
 
     function get_config(key) {
         if (server_config.data.hasOwnProperty("select_keymap_" + key)) {
@@ -365,6 +362,10 @@ define([
     window.switch_keymap = switch_keymap;
 
     return {
-        load_ipython_extension: create_menu
+        load_ipython_extension: function () {
+            return Jupyter.notebook.config.loaded
+                .then(initialize)
+                .then(create_menu);
+        }
     };
 });

--- a/src/jupyter_contrib_nbextensions/nbextensions/snippets/main.js
+++ b/src/jupyter_contrib_nbextensions/nbextensions/snippets/main.js
@@ -3,27 +3,25 @@
 define([
     'jquery',
     'base/js/namespace',
-    'base/js/dialog',
-    'base/js/utils',
-    'services/config'
-], function($, Jupyter, dialog, utils, configmod) {
+    'base/js/dialog'
+], function(
+    $,
+    Jupyter,
+    dialog
+) {
     "use strict";
 
-    // create config object to load parameters
-    var base_url = utils.get_body_data("baseUrl");
-    var config = new configmod.ConfigSection('notebook', {base_url: base_url});
-
-    config.loaded.then(function() {
+    var initialize = function () {
         var dropdown = $("<select></select>").attr("id", "snippet_picker")
                                              .css("margin-left", "0.75em")
                                              .attr("class", "form-control select-xs")
                                              .change(insert_cell);
         Jupyter.toolbar.element.append(dropdown);
-    });
+    };
 
     // will be called when the nbextension is loaded
     function load_extension() {
-        config.load(); // trigger loading config parameters
+        Jupyter.notebook.config.loaded.then(initialize); // trigger loading config parameters
 
         $.getJSON("/nbextensions/snippets/snippets.json", function(data) {
             // Add the header as the top option, does nothing on click

--- a/src/jupyter_contrib_nbextensions/nbextensions/spellchecker/main.js
+++ b/src/jupyter_contrib_nbextensions/nbextensions/spellchecker/main.js
@@ -3,9 +3,7 @@ define([
 	'jquery',
 	'base/js/events',
 	'base/js/namespace',
-	'base/js/utils',
 	'notebook/js/textcell',
-	'services/config',
 	'codemirror/lib/codemirror',
 	'./typo/typo'
 ], function (
@@ -13,9 +11,7 @@ define([
 	$,
 	events,
 	Jupyter,
-	utils,
 	textcell,
-	configmod,
 	CodeMirror,
 	Typo
 ) {
@@ -186,12 +182,9 @@ define([
 	function load_jupyter_extension () {
 		add_css('./main.css');
 
-		var base_url = utils.get_body_data('baseUrl');
-		var config = new configmod.ConfigSection('notebook', { base_url : base_url });
-		config.load();
-		config.loaded
+		return Jupyter.notebook.config.loaded
 			.then(function () {
-				$.extend(true, params, config.data.spellchecker); // update params
+				$.extend(true, params, Jupyter.notebook.config.data.spellchecker); // update params
 				if (params.add_toolbar_button) {
 					add_toolbar_buttons();
 				}

--- a/src/jupyter_contrib_nbextensions/nbextensions/splitcell/splitcell.js
+++ b/src/jupyter_contrib_nbextensions/nbextensions/splitcell/splitcell.js
@@ -2,15 +2,12 @@
 
 define([
 	'base/js/namespace',
-		'services/config',
-		'base/js/utils',
 		'base/js/events'
-], function (Jupyter, configmod, utils, events) {
+], function (
+	Jupyter,
+	events
+) {
 	"use strict";
-
-	//create config object to load paramters
-	var base_url = utils.get_body_data("baseUrl");
-	var config = new configmod.ConfigSection('notebook', {base_url: base_url});
 
 	//define default config parameter values
 	var params = {
@@ -19,6 +16,7 @@ define([
 
 	//updates default params with any specified in the server's config
 	var update_params = function(){
+		var config = Jupyter.notebook.config;
 		for (var key in params){
 			if (config.data.hasOwnProperty(key)){
 				params[key] = config.data[key];
@@ -26,7 +24,7 @@ define([
 		}
 	};
 
-	config.loaded.then(function(){
+	 var setup = function (){
 		// update defaults
 		update_params();
 
@@ -50,7 +48,7 @@ define([
 		//register keyboard shortucts with keyboard_manager
 		Jupyter.notebook.keyboard_manager.command_shortcuts.add_shortcuts(command_mode_shortcuts);
 		Jupyter.toolbar.add_buttons_group([action_full_name]);
-	});
+	};
 
 
 	var toggle_cell_style = function(){
@@ -88,7 +86,7 @@ define([
 	}
 
 	var load_extension = function() {
-		config.load();
+		Jupyter.notebook.config.loaded.then(setup);
 
 		if (Jupyter.notebook !== undefined && Jupyter.notebook._fully_loaded) {
 			// notebook already loaded. Update directly

--- a/src/jupyter_contrib_nbextensions/nbextensions/toc2/main.js
+++ b/src/jupyter_contrib_nbextensions/nbextensions/toc2/main.js
@@ -6,16 +6,12 @@ define([
     'require',
     'jquery',
     'base/js/namespace',
-    'services/config',
-    'base/js/utils',
     'notebook/js/codecell',
     './toc2'
 ], function(
     require,
     $,
     IPython,
-    configmod,
-    utils,
     codecell,
     toc2
 ) {

--- a/src/jupyter_contrib_nbextensions/nbextensions/toggle_all_line_numbers/main.js
+++ b/src/jupyter_contrib_nbextensions/nbextensions/toggle_all_line_numbers/main.js
@@ -2,20 +2,12 @@
 
 define([
     'jquery',
-    'base/js/namespace',
-    'base/js/utils',
-    'services/config'
+    'base/js/namespace'
 ], function(
     $,
-    Jupyter,
-    utils,
-    configmod
+    Jupyter
 ) {
     "use strict";
-
-    // create config object to load parameters
-    var base_url = utils.get_body_data("baseUrl");
-    var config = new configmod.ConfigSection('notebook', {base_url: base_url});
 
     // define default values for config parameters
     var params = {
@@ -26,6 +18,7 @@ define([
     // to be called once config is loaded, this updates default config vals
     // with the ones specified by the server's config file
     var update_params = function() {
+        var config = Jupyter.notebook.config;
         for (var key in params) {
             if (config.data.hasOwnProperty(key) ){
                 params[key] = config.data[key];
@@ -54,7 +47,7 @@ define([
     };
     var action_full_name; // will be set on registration
 
-    config.loaded.then(function() {
+    var initialize = function () {
         // update default config vals with the newly loaded ones
         update_params();
 
@@ -76,10 +69,10 @@ define([
             Jupyter.keyboard_manager.command_shortcuts.add_shortcut(
                 params.toggle_all_linenumbers_hotkey, action_full_name);
         }
-    });
+    };
 
     var load_ipython_extension = function() {
-        config.load();
+        return Jupyter.notebook.config.loaded.then(initialize);
     };
 
     var extension = {

--- a/src/jupyter_contrib_nbextensions/nbextensions/varInspector/main.js
+++ b/src/jupyter_contrib_nbextensions/nbextensions/varInspector/main.js
@@ -1,9 +1,18 @@
-define(["require", "jquery", "base/js/namespace", 'services/config', 
-    'base/js/events', 'base/js/utils', 'notebook/js/codecell'
-], function(require, $, Jupyter, configmod, events, utils, codecell) {
-
-    var Notebook = require('notebook/js/notebook').Notebook 
+define([
+    'require',
+    'jquery',
+    'base/js/namespace',
+    'base/js/events',
+    'notebook/js/codecell'
+], function(
+    require,
+    $,
+    Jupyter,
+    events,
+    codecell
+) {
     "use strict";
+
     var mod_name = "varInspector";
     var log_prefix = '[' + mod_name + '] ';
 
@@ -45,10 +54,7 @@ define(["require", "jquery", "base/js/namespace", 'services/config',
     st.code_init = "";
 
     function read_config(cfg, callback) { // read after nb is loaded
-        // create config object to load parameters
-        var base_url = utils.get_body_data("baseUrl");
-        var initial_cfg = $.extend(true, {}, cfg);
-        var config = Jupyter.notebook.config; //new configmod.ConfigSection('notebook', { base_url: base_url });
+        var config = Jupyter.notebook.config;
         config.loaded.then(function() {
             // config may be specified at system level or at document level.
             // first, update defaults with config loaded from server
@@ -79,7 +85,6 @@ define(["require", "jquery", "base/js/namespace", 'services/config',
             callback && callback();
             st.config_loaded = true;
         })
-        config.load();
         return cfg;
     }
 
@@ -180,8 +185,7 @@ function html_table(jsonVars) {
         // Define code_init
         // read and execute code_init 
         function read_code_init(lib) {
-            var baseUrl = require('base/js/utils').get_body_data("baseUrl")
-            var libName = baseUrl + "nbextensions/varInspector/" + lib;
+            var libName = Jupyter.notebook.base_url + "nbextensions/varInspector/" + lib;
             $.get(libName).done(function(data) {
                 st.code_init = data;
                 st.code_init = st.code_init.replace('lenName', cfg.cols.lenName).replace('lenType', cfg.cols.lenType)

--- a/src/jupyter_contrib_nbextensions/nbextensions/zenmode/main.js
+++ b/src/jupyter_contrib_nbextensions/nbextensions/zenmode/main.js
@@ -13,21 +13,14 @@ define([
     "require",
     "jquery",
     "base/js/namespace",
-    "base/js/events",
-    'base/js/utils',
-    'services/config',
+    "base/js/events"
 ], function(
     require,
     $,
     IPython,
-    events,
-    utils,
-    configmod
+    events
 ) {
     "use_strict";
-
-    var base_url = utils.get_body_data("baseUrl");
-    var config = new configmod.ConfigSection('notebook', {base_url: base_url});
 
     var backgrounds = [
         'back11.jpg', 'back12.jpg', 'back2.jpg', 'back21.jpg', 'back22.jpg',
@@ -118,7 +111,8 @@ define([
         if (getZenModeActive() != active) { toggleZenMode(background); }
     };
 
-    config.loaded.then(function() {
+    var initialize = function () {
+    	var config = IPython.notebook.config;
         if (config.data.hasOwnProperty('zenmode_use_builtin_backgrounds')) {
             if (!config.data.zenmode_use_builtin_backgrounds) {
                 console.log("not using builtin zenmode_backgrounds");
@@ -145,7 +139,7 @@ define([
                 config.data.zenmode_set_zenmode_on_load ? true : false
             );
         }
-    });
+    };
 
     var load_ipython_extension = function(background) {
         IPython.toolbar.add_buttons_group([{
@@ -162,7 +156,7 @@ define([
             'zenmode-btn-grp'
         );
         $("#maintoolbar-container").prepend($('#zenmode-btn-grp'));
-        config.load();
+        return IPython.notebook.config.loaded.then(initialize);
     };
 
     var extension = {


### PR DESCRIPTION
to avoid reloading (from server!) the same config file for each nbextension.
In most cases this also means we don't need to require the 'services/config' module any longer.