### PR TITLE
[toc2] relative links in "toc2 cell"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,15 @@ Unreleased (aka. GitHub master)
 This is where each new PR to the project should add a summary of its changes,
 which makes it much easier to fill in each release's changelog :)
 
+New features and bugfixes:
+
+- `toc2`
+  * [#1084](https://github.com/ipython-contrib/pulls/1084)
+    [@jfbercher](https://github.com/jfbercher)
+    fix for
+    [#1083](https://github.com/ipython-contrib/issue/1083):
+    Revert full url in links to relative to the current page.
+
 
 0.3.1
 -----

--- a/src/jupyter_contrib_nbextensions/nbextensions/toc2/toc2.js
+++ b/src/jupyter_contrib_nbextensions/nbextensions/toc2/toc2.js
@@ -65,7 +65,7 @@ function removeMathJaxPreview(elt) {
 var make_link = function (h, toc_mod_id) {
     var a = $('<a>')
         .attr({
-            'href': window.location.href.split('#')[0] + h.find('.anchor-link').attr('href'),
+            'href': h.find('.anchor-link').attr('href'),
             'data-toc-modified-id': toc_mod_id,
         });
     // get the text *excluding* the link text, whatever it may be


### PR DESCRIPTION
fix for #1083. Revert full url in links to relative to the current page.