### PR TITLE
Fix wrong width when cfg.widenNotebook is disabled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,11 +24,15 @@ which makes it much easier to fill in each release's changelog :)
 New features and bugfixes:
 
 - `toc2`
-  * [#1084](https://github.com/ipython-contrib/pulls/1084)
+  * [#1084](https://github.com/ipython-contrib/jupyter_contrib_nbextensions/pull/1084)
     [@jfbercher](https://github.com/jfbercher)
     fix for
     [#1083](https://github.com/ipython-contrib/issue/1083):
     Revert full url in links to relative to the current page.
+  * [#1091](https://github.com/ipython-contrib/jupyter_contrib_nbextensions/pull/1091)
+    [@fkoessel](https://github.com/fkoessel)
+    Notebook is not widened if sidebar is displayed and `cfg.widenNotebook` is
+    unchecked.
 
 
 0.3.1

--- a/src/jupyter_contrib_nbextensions/nbextensions/toc2/toc2.js
+++ b/src/jupyter_contrib_nbextensions/nbextensions/toc2/toc2.js
@@ -155,11 +155,19 @@
     }
 
     function setNotebookWidth(cfg, st) {
-        //cfg.widenNotebook  = true;
         if (cfg.sideBar) {
             if ($('#toc-wrapper').is(':visible')) {
-                $('#notebook-container').css('margin-left', $('#toc-wrapper').width() + 30)
-                $('#notebook-container').css('width', $('#notebook').width() - $('#toc-wrapper').width() - 30)
+                if (cfg.widenNotebook) {
+                    $('#notebook-container').css('margin-left', $('#toc-wrapper').width() + 30)
+                    $('#notebook-container').css('width', $('#notebook').width() - $('#toc-wrapper').width() - 30)
+                } else {
+                    var space_needed = $('#toc-wrapper').width() + 30 +
+                        $('#notebook-container').width() - $('#notebook').width();
+                    if (space_needed > 0) {
+                        $('#notebook-container').css('margin-left', $('#toc-wrapper').width() + 30)
+                        $('#notebook-container').css('width', $('#notebook-container').width() - space_needed)
+                    }
+                }
             } else {
                 if (cfg.widenNotebook) {
                     $('#notebook-container').css('margin-left', 30);


### PR DESCRIPTION
Additionally, if `cfg.widenNotebook` is enabled, it inserts dynamically
some margin if the TOC sidebar needs more space.