### PR TITLE
[various] bugfix toolbar buttons with id

### DIFF
--- a/src/jupyter_contrib_nbextensions/nbextensions/datestamper/main.js
+++ b/src/jupyter_contrib_nbextensions/nbextensions/datestamper/main.js
@@ -26,14 +26,13 @@ define([
     };
 
     var load_ipython_extension = function () {
-        IPython.toolbar.add_buttons_group([{
-            id: 'datestamp',
-            action: IPython.keyboard_manager.actions.register ({
+        IPython.toolbar.add_buttons_group([
+            IPython.keyboard_manager.actions.register ({
                 help   : 'insert datestamp',
                 icon   : 'fa-calendar',
                 handler: datestamp
             }, 'insert-datestamp', 'datestamp')
-        }]);
+        ]);
     };
 
     var extension = {

--- a/src/jupyter_contrib_nbextensions/nbextensions/equation-numbering/main.js
+++ b/src/jupyter_contrib_nbextensions/nbextensions/equation-numbering/main.js
@@ -13,9 +13,8 @@ define([
     var MathJax = window.MathJax;
 
     var load_ipython_extension = function() {
-        Jupyter.toolbar.add_buttons_group([{
-            id: 'reset_numbering',
-            action: Jupyter.keyboard_manager.actions.register ({
+        var btn_grp = Jupyter.toolbar.add_buttons_group([
+            Jupyter.keyboard_manager.actions.register ({
                 help   : 'Reset equation numbering',
                 icon   : 'fa-sort-numeric-asc',
                 handler: function () {
@@ -27,7 +26,8 @@ define([
                     $('#reset_numbering').blur();
                 }
             }, 'reset-numbering', 'equation_numbering')
-        }]);
+        ]);
+        $(btn_grp).find('.btn').attr('id', 'reset_numbering');
         MathJax.Hub.Config({
           TeX: { equationNumbers: { autoNumber: "AMS" } }
         });

--- a/src/jupyter_contrib_nbextensions/nbextensions/exercise/main.js
+++ b/src/jupyter_contrib_nbextensions/nbextensions/exercise/main.js
@@ -131,9 +131,8 @@ define([
         }
         
 function load_ipython_extension(){
-    IPython.toolbar.add_buttons_group([{
-            id: 'hide_solutions',
-            action: IPython.keyboard_manager.actions.register ({
+        IPython.toolbar.add_buttons_group([
+            IPython.keyboard_manager.actions.register ({
                 help    : 'Exercise: Create/Remove solutions',
                 icon    : 'fa-mortar-board',
                 handler : function () {
@@ -141,7 +140,7 @@ function load_ipython_extension(){
                     hide_solutions();
                     }
             }, 'hide_solutions', 'exercise')
-         }]);
+        ]);
 
      /**
      * load css file and append to document

--- a/src/jupyter_contrib_nbextensions/nbextensions/exercise2/main.js
+++ b/src/jupyter_contrib_nbextensions/nbextensions/exercise2/main.js
@@ -127,16 +127,15 @@ id=\"myCheck' + cbx + '\"  >\
         }
         
 function load_ipython_extension(){
-    IPython.toolbar.add_buttons_group([{
-            id: 'process_solution',
-            action: IPython.keyboard_manager.actions.register ({
+        IPython.toolbar.add_buttons_group([
+            IPython.keyboard_manager.actions.register ({
                 help    : 'Exercise2: Create/Remove solution',
                 icon    : 'fa-toggle-on',
                 handler : function () {
                     process_solution();
                     }
             }, 'process_solution', 'exercise2')
-         }]);
+        ]);
 
 
 

--- a/src/jupyter_contrib_nbextensions/nbextensions/export_embedded/main.js
+++ b/src/jupyter_contrib_nbextensions/nbextensions/export_embedded/main.js
@@ -33,16 +33,15 @@ define([
         
         /* Add also a Button, currently disabled */
         /*
-        Jupyter.toolbar.add_buttons_group([{
-            id: 'export_embeddedhtml',
-            action: Jupyter.keyboard_manager.actions.register ({
+        Jupyter.toolbar.add_buttons_group([
+        Jupyter.keyboard_manager.actions.register ({
             help   : 'Embedded HTML Export',
             icon   : 'fa-save',
             handler: function() {
                 Jupyter.menubar._nbconvert('html_embed', true);
             }
         }, 'export-embedded-html', 'export_embedded')
-        }]);
+        ]);
         */
         if (Jupyter.notebook !== undefined && Jupyter.notebook._fully_loaded) {
             // notebook_loaded.Notebook event has already happened

--- a/src/jupyter_contrib_nbextensions/nbextensions/freeze/main.js
+++ b/src/jupyter_contrib_nbextensions/nbextensions/freeze/main.js
@@ -160,28 +160,23 @@ define([
     }
 
     function load_extension () {
-        Jupyter.toolbar.add_buttons_group([{
-            id: 'make_normal',
-            action: Jupyter.keyboard_manager.actions.register ({
+        Jupyter.toolbar.add_buttons_group([
+            Jupyter.keyboard_manager.actions.register ({
                 help : 'lift restrictions from selected cells',
                 icon : 'fa-unlock-alt',
                 handler : make_normal_selected
-            }, 'make-cells-normal', mod_name)
-        }, {
-            id: 'make_read_only',
-            action: Jupyter.keyboard_manager.actions.register({
+            }, 'make-cells-normal', mod_name),
+            Jupyter.keyboard_manager.actions.register({
                 help : 'make selected cells read-only',
                 icon: 'fa-lock',
                 handler : make_read_only_selected
             }, 'make-cells-read-only', mod_name),
-        }, {
-            id: 'freeze_cells',
-            action: Jupyter.keyboard_manager.actions.register({
+            Jupyter.keyboard_manager.actions.register({
                 help : 'freeze selected cells',
                 icon : 'fa-asterisk',
                 handler : make_frozen_selected
             }, 'freeze-cells', mod_name)
-        }]);
+        ]);
 
         patch_CodeCell_execute();
         patch_MarkdownCell_unrender();

--- a/src/jupyter_contrib_nbextensions/nbextensions/help_panel/help_panel.js
+++ b/src/jupyter_contrib_nbextensions/nbextensions/help_panel/help_panel.js
@@ -53,9 +53,8 @@ define([
     var initialize = function () {
         update_params();
         if (params.help_panel_add_toolbar_button) {
-            IPython.toolbar.add_buttons_group([{
-                id: 'btn_help_panel',
-                action: IPython.keyboard_manager.actions.register({
+            $(IPython.toolbar.add_buttons_group([
+                IPython.keyboard_manager.actions.register({
                     help   : 'Show help panel',
                     icon   : 'fa-book',
                     handler: function() {
@@ -64,8 +63,8 @@ define([
                         setTimeout(function() { btn.blur(); }, 500);
                     }
                 }, 'show-help-panel', 'help_panel'),
-            }]);
-            $('#btn_help_panel').attr({
+            ])).find('.btn').attr({
+                id: 'btn_help_panel',
                 'data-toggle': 'button',
                 'aria-pressed': 'false'
             });

--- a/src/jupyter_contrib_nbextensions/nbextensions/hide_input/main.js
+++ b/src/jupyter_contrib_nbextensions/nbextensions/hide_input/main.js
@@ -30,9 +30,8 @@ define([
     var load_ipython_extension = function() {
 
         // Add a button to the toolbar
-        Jupyter.toolbar.add_buttons_group([{
-            id: 'btn-hide-input',
-            action: Jupyter.keyboard_manager.actions.register ({
+        $(Jupyter.toolbar.add_buttons_group([
+            Jupyter.keyboard_manager.actions.register({
                 help   : 'Toggle selected cell input display',
                 icon   : 'fa-chevron-up',
                 handler: function() {
@@ -40,7 +39,7 @@ define([
                     setTimeout(function() { $('#btn-hide-input').blur(); }, 500);
                 }
             }, 'toggle-cell-input-display', 'hide_input')
-        }]);
+        ])).find('.btn').attr('id', 'btn-hide-input');
         // Collapse all cells that are marked as hidden
         if (Jupyter.notebook !== undefined && Jupyter.notebook._fully_loaded) {
             // notebook already loaded. Update directly

--- a/src/jupyter_contrib_nbextensions/nbextensions/hide_input_all/main.js
+++ b/src/jupyter_contrib_nbextensions/nbextensions/hide_input_all/main.js
@@ -36,9 +36,8 @@ define([
     }
 
     var load_ipython_extension = function() {
-        Jupyter.toolbar.add_buttons_group([{
-            id: 'toggle_codecells',
-            action: Jupyter.keyboard_manager.actions.register ({
+        $(Jupyter.toolbar.add_buttons_group([
+            Jupyter.keyboard_manager.actions.register({
                 help   : 'Hide codecell inputs',
                 icon   : 'fa-eye',
                 handler: function() {
@@ -46,7 +45,7 @@ define([
                     setTimeout(function() { $('#toggle_codecells').blur(); }, 500);
                 }
             }, 'hide-codecell-inputs', 'hide_input_all'),
-        }]);
+        ])).find('.btn').attr('id', 'toggle_codecells');
         if (Jupyter.notebook !== undefined && Jupyter.notebook._fully_loaded) {
             // notebook_loaded.Notebook event has already happened
             initialize();

--- a/src/jupyter_contrib_nbextensions/nbextensions/nbTranslate/main.js
+++ b/src/jupyter_contrib_nbextensions/nbextensions/nbTranslate/main.js
@@ -59,21 +59,18 @@ define(function(require, exports, module) {
 
     function showToolbar() {
         if ($('#showToolbar').length == 0) {
-            Jupyter.toolbar.add_buttons_group([
-                {
-                    id: 'showToolbar',
-                    action: Jupyter.keyboard_manager.actions.register ({
-                        'help'   : 'Translate current cell',
-                        'icon'   : 'fa-language',
-                        'handler': translateCurrentCell,
-                    }, 'translate-cell', 'nbTranslate'),
-                },
-                Jupyter.keyboard_manager.actions.register ({
+            $(Jupyter.toolbar.add_buttons_group([
+                Jupyter.keyboard_manager.actions.register({
+                    'help'   : 'Translate current cell',
+                    'icon'   : 'fa-language',
+                    'handler': translateCurrentCell,
+                }, 'translate-cell', 'nbTranslate'),
+                Jupyter.keyboard_manager.actions.register({
                     'help'   : 'nbTranslate: Configuration (toggle toolbar)',
                     'icon'   : 'fa-wrench',
                     'handler': translateToolbarToggle //translateToolbar
                 }, 'show-nbTranslate-toolbar', 'nbTranslate'),
-            ]);
+            ])).find('.btn').eq(0).attr('id', 'showToolbar');
         }
     }
 

--- a/src/jupyter_contrib_nbextensions/nbextensions/notify/notify.js
+++ b/src/jupyter_contrib_nbextensions/nbextensions/notify/notify.js
@@ -64,14 +64,13 @@ define([
 
   var add_permissions_button = function () {
     if ($("#permissions-button").length === 0) {
-      Jupyter.toolbar.add_buttons_group([{
-        id: 'permissions-button',
-        action: Jupyter.keyboard_manager.actions.register ({
+      $(Jupyter.toolbar.add_buttons_group([
+        Jupyter.keyboard_manager.actions.register ({
           'help'   : 'Grant Notification Permissions',
           'icon'   : 'fa-check',
           'handler': ask_permission,
         },'grant-notifications-permission', 'notify')
-      }]);
+      ])).find('.btn').attr('id', 'permissions-button');
     }
   };
 

--- a/src/jupyter_contrib_nbextensions/nbextensions/printview/main.js
+++ b/src/jupyter_contrib_nbextensions/nbextensions/printview/main.js
@@ -59,14 +59,13 @@ define([
 	};
 
 	var load_ipython_extension = function() {
-		IPython.toolbar.add_buttons_group([{
-			id: 'doPrintView',
-			action: IPython.keyboard_manager.actions.register ({
+		$(IPython.toolbar.add_buttons_group([
+			IPython.keyboard_manager.actions.register ({
 				help   : 'Create static print view',
 				icon   : 'fa-print',
 				handler: nbconvertPrintView
 			}, 'create-static-printview',  'printview'),
-		}]);
+		])).find('.btn').attr('id', 'doPrintView');
         return IPython.notebook.config.loaded.then(initialize);
 	};
 

--- a/src/jupyter_contrib_nbextensions/nbextensions/qtconsole/qtconsole.js
+++ b/src/jupyter_contrib_nbextensions/nbextensions/qtconsole/qtconsole.js
@@ -5,19 +5,18 @@ define([
     'base/js/events'
     ], function(Jupyter, events) {
         var load_ipython_extension = function () {
-            Jupyter.toolbar.add_buttons_group([{
+            Jupyter.toolbar.add_buttons_group([
                 /**
                  * Button to launch QTConsole
                  */
-                id: 'qtconsole',
-                action: Jupyter.keyboard_manager.actions.register ({
+                Jupyter.keyboard_manager.actions.register ({
                      'help'   : 'Run QTConsole',
                      'icon'   : 'fa-terminal',
                      'handler': function () {
                          Jupyter.notebook.kernel.execute('%qtconsole')
                      }
                 }, 'run-qtconsole', 'qtconsole')
-            }]);
+            ]);
         };
         return {
             load_ipython_extension : load_ipython_extension

--- a/src/jupyter_contrib_nbextensions/nbextensions/runtools/main.js
+++ b/src/jupyter_contrib_nbextensions/nbextensions/runtools/main.js
@@ -77,15 +77,13 @@ define([
         add_gutter_events();
 
         /* Add run control buttons to toolbar */
-        Jupyter.toolbar.add_buttons_group([{
-            id: 'toggle_runtools',
-            action: Jupyter.keyboard_manager.actions.register ({
+        $(Jupyter.toolbar.add_buttons_group([
+            Jupyter.keyboard_manager.actions.register ({
                 help: 'Toggle Runtools Toolbar',
                 icon: 'fa-cogs',
                 handler: toggle_toolbar
             }, 'toggle-runtools-toolbar', 'runtools')
-        }]);
-        $("#toggle_runtools").css({
+        ])).find('.btn').attr('id', 'toggle_runtools').css({
             'outline': 'none'
         });
 

--- a/src/jupyter_contrib_nbextensions/nbextensions/scroll_down/main.js
+++ b/src/jupyter_contrib_nbextensions/nbextensions/scroll_down/main.js
@@ -28,14 +28,13 @@ define([
     }
 
     function load_extension() {
-        Jupyter.toolbar.add_buttons_group([{
-            id: 'toggle_scroll_down',
-            action: Jupyter.keyboard_manager.actions.register({
+        $(Jupyter.toolbar.add_buttons_group([
+            Jupyter.keyboard_manager.actions.register({
                 help   : 'toggle automatic scrolling down',
                 icon   : 'fa-angle-double-down ',
                 handler: toggleScrollDown
             }, 'toggle-auto-scroll-down', 'scroll_down')
-        }]);
+        ])).find('.btn').attr('id', 'toggle_runtools');
 
         console.log("[ScrollDown] is loaded");
 

--- a/src/jupyter_contrib_nbextensions/nbextensions/spellchecker/main.js
+++ b/src/jupyter_contrib_nbextensions/nbextensions/spellchecker/main.js
@@ -148,9 +148,8 @@ define([
 	 * Add a button to the jupyter toolbar for toggling spellcheck overlay
 	 */
 	function add_toolbar_buttons () {
-		return Jupyter.toolbar.add_buttons_group([{
-			id: 'spellchecker_btn',
-		    action: Jupyter.keyboard_manager.actions.register ({
+		return $(Jupyter.toolbar.add_buttons_group([
+			Jupyter.keyboard_manager.actions.register ({
 				help   : 'Toggle spell checking on markdown cells',
 				icon   : 'fa-check',
 				handler: function (evt) {
@@ -160,7 +159,7 @@ define([
 					}, 100);
 				}
 		    }, 'toggle-spellchecking', 'spellchecker')
-		}]);
+		])).find('.btn').attr('id', 'spellchecker_btn');
 	}
 
 	/**

--- a/src/jupyter_contrib_nbextensions/nbextensions/toc2/main.js
+++ b/src/jupyter_contrib_nbextensions/nbextensions/toc2/main.js
@@ -125,14 +125,13 @@ define([
             return;
         }
         if ($("#toc_button").length === 0) {
-            IPython.toolbar.add_buttons_group([{
-                id: 'toc_button',
-                action: Jupyter.keyboard_manager.actions.register ({
+            $(IPython.toolbar.add_buttons_group([
+                Jupyter.keyboard_manager.actions.register ({
                     'help'   : 'Table of Contents',
                     'icon'   : 'fa-list',
                     'handler': toggleToc,
                 }, 'toggle-toc', 'toc2')
-            }]);
+            ])).find('.btn').attr('id', 'toc_button');
         }
     };
 

--- a/src/jupyter_contrib_nbextensions/nbextensions/varInspector/main.js
+++ b/src/jupyter_contrib_nbextensions/nbextensions/varInspector/main.js
@@ -100,14 +100,13 @@ define([
             return;
         }
         if ($("#varInspector_button").length === 0) {
-            Jupyter.toolbar.add_buttons_group([{
-                id: 'varInspector_button',
-                action: Jupyter.keyboard_manager.actions.register ({
+            $(Jupyter.toolbar.add_buttons_group([
+                Jupyter.keyboard_manager.actions.register ({
                     'help'   : 'Variable Inspector',
                     'icon'   : 'fa-crosshairs',
                     'handler': toggleVarInspector,
                 }, 'toggle-variable-inspector', 'varInspector')
-            }]);
+            ])).find('.btn').attr('id', 'varInspector_button');
         }
     };
 

--- a/src/jupyter_contrib_nbextensions/nbextensions/zenmode/main.js
+++ b/src/jupyter_contrib_nbextensions/nbextensions/zenmode/main.js
@@ -161,9 +161,8 @@ define([
     };
 
     var load_ipython_extension = function(background) {
-        IPython.toolbar.add_buttons_group([{
-            id: 'zenmode-toggle-btn',
-            action: IPython.keyboard_manager.actions.register({
+        $(IPython.toolbar.add_buttons_group([
+            IPython.keyboard_manager.actions.register({
                 'help'   : 'Enter/Exit Zenmode',
                 'icon'    : 'fa-empire',
                 'handler': function() {
@@ -173,7 +172,7 @@ define([
                     }, 500);
                 },
             }, 'toggle-zenmode', 'zenmode'),
-        }], 'zenmode-btn-grp');
+        ], 'zenmode-btn-grp')).find('.btn').attr('id', 'zenmode-toggle-btn');
         $("#maintoolbar-container").prepend($('#zenmode-btn-grp'));
         return IPython.notebook.config.loaded.then(initialize);
     };


### PR DESCRIPTION
the ability to specify an action and an id was only added in notebook 5.2.0 (in https://github.com/jupyter/notebook/commit/af244a63b82c03d01783d29d0f821d1dcade8709), so any release before that fails to create buttons using the `{id: 'btn-id', action: }` syntax. This pr fixes the relevant bugs introduced in #1123