### PR TITLE
Improve hide input by keeping the cell toolbar visible

### DIFF
--- a/src/jupyter_contrib_nbextensions/nbextensions/hide_input/main.js
+++ b/src/jupyter_contrib_nbextensions/nbextensions/hide_input/main.js
@@ -15,14 +15,14 @@ define([
         // Find the selected cell
         var cell = Jupyter.notebook.get_selected_cell();
         // Toggle visibility of the input div
-        cell.element.find("div.input").toggle('slow');
+        cell.element.find("div.input_area").toggle('slow');
         cell.metadata.hide_input = ! cell.metadata.hide_input;
     };
 
     var update_input_visibility = function () {
         Jupyter.notebook.get_cells().forEach(function(cell) {
             if (cell.metadata.hide_input) {
-                cell.element.find("div.input").hide();
+                cell.element.find("div.input_area").hide();
             }
         })
     };


### PR DESCRIPTION
Hi,
Here is the pull request from the suggestion to hide only the input_area while keeping the cell toolbar visible while hiding inputs with the "Hide_input" extension.

Cheers and Enjoy!

Olivier