### PR TITLE
Update code_prettify.yaml

### DIFF
--- a/src/jupyter_contrib_nbextensions/nbextensions/code_prettify/code_prettify.yaml
+++ b/src/jupyter_contrib_nbextensions/nbextensions/code_prettify/code_prettify.yaml
@@ -56,8 +56,8 @@ Parameters:
     {
       "python": {
         "library": "import json\ndef yapf_reformat(cell_text):\n    import yapf.yapflib.yapf_api\n    import re\n    cell_text = re.sub('^%', '#%#', cell_text, flags=re.M)\n    reformated_text = yapf.yapflib.yapf_api.FormatCode(cell_text)[0]\n    return re.sub('^#%#', '%', reformated_text, flags=re.M)",
-        "prefix": "print(json.dumps(yapf.yapflib.yapf_api.FormatCode(u",
-        "postfix": ")[0]))"
+        "prefix": "print(json.dumps(yapf_reformat(u",
+        "postfix": ")))"
       },
       "r": {
         "library": "library(formatR)\nlibrary(jsonlite)",


### PR DESCRIPTION
In the pull request #1019 to fix #1018, we define `yapf_reformat()` function in python `library`. This pull request uses that function for python `prefix`.