### PR TITLE
[toc2] only set notebook dirty if metadata item changed

### DIFF
--- a/src/jupyter_contrib_nbextensions/nbextensions/toc2/toc2.js
+++ b/src/jupyter_contrib_nbextensions/nbextensions/toc2/toc2.js
@@ -99,8 +99,11 @@
             if (md === undefined) {
                 md = IPython.notebook.metadata.toc = {};
             }
+            var old_val = md[key];
             md[key] = value;
-            IPython.notebook.set_dirty();
+            if (typeof _ !== undefined ? !_.isEqual(value, old_val) : old_val != value) {
+                IPython.notebook.set_dirty();
+            }
         }
         return value;
     };


### PR DESCRIPTION
ToC setting the notebook dirty every time it loaded was annoying me.
This uses deep compare if underscore is available.
In other cases, the shallow compare means object like toc_position will
always look changed, but that's ok, as it only gets set when something
gets moved anyway.