### PR TITLE
[install] don't check for running notebook servers when installing

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,9 +167,10 @@ config-editing operations, or only the file-copy operations:
     - `jupyter_notebook_config.json` to enable the serverextension
       `jupyter_nbextensions_configurator`.
 
-Finally, the `--skip-running-check` option flag is provided in order to allow
-the installation to proceed even if a notebook server appears to be currently
-running (by default, the install will not be performed if a notebook server
+Finally, the `--perform-running-check` option flag is provided in order to
+prevent the installation from proceeding if a notebook server appears to be
+currently running
+(by default, the install will still be performed, even if a notebook server
 appears to be running).
 
 An analogous `uninstall` command is also provided, to remove all of the

--- a/docs/source/install.md
+++ b/docs/source/install.md
@@ -99,9 +99,10 @@ config-editing operations, or only the file-copy operations:
     - `jupyter_notebook_config.json` to enable the serverextension
       `jupyter_nbextensions_configurator`.
 
-Finally, the `--skip-running-check` option flag is provided in order to allow
-the installation to proceed even if a notebook server appears to be currently
-running (by default, the install will not be performed if a notebook server
+Finally, the `--perform-running-check` option flag is provided in order to
+prevent the installation from proceeding if a notebook server appears to be
+currently running
+(by default, the install will still be performed, even if a notebook server
 appears to be running).
 
 An analogous `uninstall` command is also provided, to remove all of the

--- a/docs/source/troubleshooting.md
+++ b/docs/source/troubleshooting.md
@@ -6,19 +6,6 @@ repository, some old files might be left on your system. This can lead, for
 example, to having all the nbextensions listed twice on the configurator page.
 
 
-Cannot configure while the Jupyter notebook server is running
--------------------------------------------------------------
-If you get this error message during installation, a running instance of the
-Jupyter notebook server has been detected. You can check this by running
-
-    jupyter notebook list
-
-Sometimes the result can be incorrect. So if you are sure you have no notebook
-servers running, you can force the notebook extension installation step using the
-`--skip-running-check` prefix. For example:
-
-    jupyter contrib nbextensions install --sys-prefix --skip-running-check
-
 Removing Double Entries
 -----------------------
 The nbextensions from older versions will be located in the `nbextensions`

--- a/src/jupyter_contrib_nbextensions/application.py
+++ b/src/jupyter_contrib_nbextensions/application.py
@@ -77,6 +77,11 @@ class BaseContribNbextensionsInstallApp(BaseContribNbextensionsApp):
                 {'skip_running_check': True}},
             'Perform actions even if notebook server(s) are already running'
         ),
+        'perform-running-check': (
+            {'BaseContribNbextensionsInstallApp':
+                {'skip_running_check': False}},
+            'Only perform actions if no notebook server(s) are running'
+        ),
     }
 
     _conflicting_flagsets = [['--user', '--system', '--sys-prefix'], ]
@@ -98,7 +103,7 @@ class BaseContribNbextensionsInstallApp(BaseContribNbextensionsApp):
         help='Full path to nbextensions dir '
         '(consider instead using system, sys_prefix, prefix or user option)')
     skip_running_check = Bool(
-        False, config=True,
+        True, config=True,
         help='Perform actions even if notebook server(s) are already running')
 
     def parse_command_line(self, argv=None):

--- a/src/jupyter_contrib_nbextensions/install.py
+++ b/src/jupyter_contrib_nbextensions/install.py
@@ -37,9 +37,7 @@ def toggle_install(install, user=False, sys_prefix=False, overwrite=False,
                    symlink=False, prefix=None, nbextensions_dir=None,
                    logger=None, skip_running_check=False):
     """Install or remove all jupyter_contrib_nbextensions files & config."""
-    if not skip_running_check and notebook_is_running():
-        raise NotebookRunningError(
-            'Cannot configure while the Jupyter notebook server is running')
+    _err_on_running(skip_running_check=skip_running_check)
     _check_conflicting_kwargs(user=user, sys_prefix=sys_prefix, prefix=prefix,
                               nbextensions_dir=nbextensions_dir)
     toggle_install_files(
@@ -55,9 +53,7 @@ def toggle_install_files(install, user=False, sys_prefix=False, logger=None,
                          overwrite=False, symlink=False, prefix=None,
                          nbextensions_dir=None, skip_running_check=False):
     """Install/remove jupyter_contrib_nbextensions files."""
-    if not skip_running_check and notebook_is_running():
-        raise NotebookRunningError(
-            'Cannot configure while the Jupyter notebook server is running')
+    _err_on_running(skip_running_check=skip_running_check)
     kwargs = dict(user=user, sys_prefix=sys_prefix, prefix=prefix,
                   nbextensions_dir=nbextensions_dir)
     _check_conflicting_kwargs(**kwargs)
@@ -84,9 +80,7 @@ def toggle_install_files(install, user=False, sys_prefix=False, logger=None,
 def toggle_install_config(install, user=False, sys_prefix=False,
                           skip_running_check=False, logger=None):
     """Install/remove contrib nbextensions to/from jupyter_nbconvert_config."""
-    if not skip_running_check and notebook_is_running():
-        raise NotebookRunningError(
-            'Cannot configure while the Jupyter notebook server is running')
+    _err_on_running(skip_running_check=skip_running_check)
     _check_conflicting_kwargs(user=user, sys_prefix=sys_prefix)
     config_dir = nbextensions._get_config_dir(user=user, sys_prefix=sys_prefix)
     if logger:
@@ -170,6 +164,29 @@ def uninstall(user=False, sys_prefix=False, prefix=None, nbextensions_dir=None,
 # -----------------------------------------------------------------------------
 # Private API
 # -----------------------------------------------------------------------------
+
+
+def _err_on_running(skip_running_check=False, runtime_dir=None):
+    if skip_running_check:
+        return
+    try:
+        srv = next(list_running_servers(runtime_dir=runtime_dir))
+    except StopIteration:
+        return
+
+    raise NotebookRunningError("""
+Will not configure while a Jupyter notebook server appears to be running.
+At least this server appears to be running:
+
+  {}
+
+Note that the json file indicating that this server is running may
+be stale, see
+
+    https://github.com/jupyter/notebook/issues/2829
+
+for further details.
+""".format(srv))
 
 
 def _check_conflicting_kwargs(**kwargs):


### PR DESCRIPTION
Various other packages which do similar editing of jupyter_notebook_config files don't make this check. Since it's not a routinely-edited file, we're unlikely to run into collisions with other edits being made at the same time, so I think we can do without this check. Making it an opt-in check will allow people to be more cautious and keep the check, while removing the headaches of the false positives preventing installs from working...