### PR TITLE
FIXES #1223 and improves the user experience

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -118,6 +118,10 @@ New features and bugfixes:
  - `code_prettify` Update `code_prettify.yaml`
    [#1162](https://github.com/ipython-contrib/jupyter_contrib_nbextensions/pull/1162)
    [@fehiepsi](https://github.com/fehiepsi)
+ - `init_cell`
+   * Warning dialog now always relevant, fixes [#1223].(https://github.com/ipython-contrib/jupyter_contrib_nbextensions/issues/1223)
+     [#1226](https://github.com/ipython-contrib/jupyter_contrib_nbextensions/pull/1226)
+     [@consideratio](https://github.com/consideratio)
 
 
 0.3.3


### PR DESCRIPTION
* FIXES #1223 - Only shows the dialog about untrusted notebooks if there was any initialization cells in it.
* UX improvement - Adding a button to do the same action as available in the menu "File -> Trust Notebook", it will require an additional confirmation.

![init_code_ux](https://user-images.githubusercontent.com/3837114/35774743-7151c2aa-0978-11e8-8199-1c4153c90763.png)

![trust_notebook](https://user-images.githubusercontent.com/3837114/35774754-e57441ee-0978-11e8-970d-1a06e9eff984.png)

