### PR TITLE
[kernel_exec_on_cell] fix shift-click handling

### DIFF
--- a/src/jupyter_contrib_nbextensions/nbextensions/code_prettify/kernel_exec_on_cell.js
+++ b/src/jupyter_contrib_nbextensions/nbextensions/code_prettify/kernel_exec_on_cell.js
@@ -183,18 +183,28 @@ define([
     };
 
     KernelExecOnCells.prototype.add_toolbar_button = function() {
-        if ($('#' + this.mod_name + '_button').length < 1) {
-            var button_group_id = this.mod_name + '_button';
+        var action_name = this.mod_name;
+        var prefix = "kernel_exec_on_cell";
+        // select toolbar button based on data attribute
+        var data_attribute = '[data-jupyter-action="' + prefix + ':' + action_name + '"]';
+        if ($(data_attribute).length < 1) {
             var that = this;
-            Jupyter.toolbar.add_buttons_group([{
-                label: this.cfg.kbd_shortcut_text + ' selected cell(s) (add shift for all cells)',
-                icon: this.cfg.button_icon,
-                callback: function(evt) {
+            var handler = function (evt) {
+                var button = $(data_attribute);
+                $("button").click(function(evt) {
                     that.autoformat_cells(
                         evt.shiftKey ? Jupyter.notebook.get_cells().map(function (cell, idx) { return idx; }) : undefined
-                    );
-                },
-            }], button_group_id);
+                      );
+                  });
+        };
+        var action = {
+            icon: that.cfg.button_icon,
+            help: that.cfg.kbd_shortcut_text + ' selected cell(s) (add shift for all cells)',
+            help_index: 'yf',
+            handler: handler
+        };
+        var full_action_name = Jupyter.actions.register(action, action_name, prefix);
+        Jupyter.toolbar.add_buttons_group([full_action_name]);
         }
     };
 
@@ -288,7 +298,6 @@ define([
                     }
                 }, { silent: false }
             );
-
         }
     };
 


### PR DESCRIPTION
Fixed the label on buttons and correctly handle shift click on button based on data attribute.

BEFORE, the label was added to the button:

![image](https://user-images.githubusercontent.com/1004282/36352068-80da4878-14b3-11e8-9a92-8497254fe115.png)

AFTER, the label is included correctly in the title of the button.

![image](https://user-images.githubusercontent.com/1004282/36352091-f0905d92-14b3-11e8-87c7-89d9764fd9a9.png)

Also, the shiftKey event wasn't handled correctly and didn't work on my machine.