### PR TITLE
[toc2] fix css rule for overriding wrapper color

### DIFF
--- a/src/jupyter_contrib_nbextensions/nbextensions/toc2/main.js
+++ b/src/jupyter_contrib_nbextensions/nbextensions/toc2/main.js
@@ -101,7 +101,7 @@ define([
                 "padding-left: 20px; }"
         }
         // Using custom colors
-        sheet.innerHTML += ".float-wrapper, .sidebar-wrapper { background-color: " + cfg.colors.wrapper_background + "}";
+        sheet.innerHTML += "#toc-wrapper { background-color: " + cfg.colors.wrapper_background + "}\n";
         sheet.innerHTML += "#toc a, #navigate_menu a, .toc { color: " + cfg.colors.navigate_text + "}";
         sheet.innerHTML += "#toc-wrapper .toc-item-num { color: " + cfg.colors.navigate_num + "}";
         sheet.innerHTML += ".sidebar-wrapper { border-color: " + cfg.colors.sidebar_border + "}";


### PR DESCRIPTION
This is a fix for https://github.com/Jupyter-contrib/jupyter_nbextensions_configurator/issues/59, which turned out to actually be an issue with toc2