### PR TITLE
Fixed collapsible_headings key conflict

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,8 @@ New features and bugfixes:
  - Add preprocessor to embed images into a notebook
    [#1067](https://github.com/ipython-contrib/jupyter_contrib_nbextensions/pull/1067)
    [@juhasch](https://github.com/juhasch)
+ - Fixed conflicts in collapsible_headings if keys are rebound.
+   [@rhilenova](https://github.com/rhilenova)
 
 
 0.4.0

--- a/src/jupyter_contrib_nbextensions/nbextensions/collapsible_headings/main.js
+++ b/src/jupyter_contrib_nbextensions/nbextensions/collapsible_headings/main.js
@@ -634,7 +634,7 @@
 
 				var kbm = Jupyter.keyboard_manager;
 
-				var action_up = kbm.actions.get(kbm.command_shortcuts.get_shortcut('up'));
+				var action_up = kbm.actions.get("jupyter-notebook:select-previous-cell");
 				var orig_up_handler = action_up.handler;
 				action_up.handler = function (env) {
 					for (var index = env.notebook.get_selected_index() - 1; (index !== null) && (index >= 0); index--) {
@@ -647,7 +647,7 @@
 					return orig_up_handler.apply(this, arguments);
 				};
 
-				var action_down = kbm.actions.get(kbm.command_shortcuts.get_shortcut('down'));
+				var action_down = kbm.actions.get("jupyter-notebook:select-next-cell");
 				var orig_down_handler = action_down.handler;
 				action_down.handler = function (env) {
 					var ncells = env.notebook.ncells();


### PR DESCRIPTION
I ran into an issue while using the jupyter vim binding plugin (https://github.com/lambdalisue/jupyter-vim-binding). Collapsible headings was changing the handler for whatever was on the "up" and "down" keys, rather than the handlers for moving to the previous and next cells. If nothing is bound to "up" or "down", or those keys were rebound before the plugin loaded, it causes issues.