### PR TITLE
fix travis for py27

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -38,7 +38,7 @@ matrix:
       env: TOXENV=condarecipe
     # linux, various python and notebook versions
     - os: linux
-      python: '3.4'
+      python: '2.7'
       env: TOXENV=py27-notebook
     - os: linux
       python: '3.3'

--- a/tox.ini
+++ b/tox.ini
@@ -44,6 +44,7 @@ deps =
     notebookmaster: https://github.com/jupyter/notebook/archive/master.zip
     notebook: notebook
 commands =
+    python --version
     {posargs:coverage run --source=src -m nose -vv tests}
 
 [testenv:check]


### PR DESCRIPTION
incorrect python version meant tox was pulling an out-of-date py27