### PR TITLE
require newer jupyter_highlight_selected_word

### DIFF
--- a/conda.recipe/meta.yaml
+++ b/conda.recipe/meta.yaml
@@ -24,7 +24,7 @@ requirements:
     - ipython_genutils
     - jupyter_contrib_core >=0.3.3
     - jupyter_core
-    - jupyter_highlight_selected_word >=0.0.10
+    - jupyter_highlight_selected_word >=0.1.1
     - jupyter_latex_envs >=1.3.8
     - jupyter_nbextensions_configurator >=0.4.0
     - nbconvert >=4.2

--- a/setup.py
+++ b/setup.py
@@ -64,7 +64,7 @@ if you encounter any problems, and create a new issue if needed!
             'ipython_genutils',
             'jupyter_contrib_core >=0.3.3',
             'jupyter_core',
-            'jupyter_highlight_selected_word >=0.0.10',
+            'jupyter_highlight_selected_word >=0.1.1',
             'jupyter_latex_envs >=1.3.8',
             'jupyter_nbextensions_configurator >=0.4.0',
             'nbconvert >=4.2',


### PR DESCRIPTION
To ensure we get a non-zipped version installed.

Fixes #1269 (once in release)