### PR TITLE
pandas: Split-apply-combine (2 funcs: count, mean)

### DIFF
--- a/src/jupyter_contrib_nbextensions/nbextensions/snippets_menu/snippets_submenus_python/pandas.js
+++ b/src/jupyter_contrib_nbextensions/nbextensions/snippets_menu/snippets_submenus_python/pandas.js
@@ -113,7 +113,16 @@ define({
 
         {
             'name' : 'Combining',
-            'snippet' : ['',],
+            'sub-menu' : [
+                {
+                    'name' : 'Split-apply-combine (sum)',
+                    'snippet' : ['df['label_count'] = df.groupby('label', as_index=False)['label'].transform(lambda x: x.count())',],
+                },
+                {
+                    'name' : 'Split-apply-combine (mean)',
+                    'snippet' : ['df['label_mean'] = df.groupby('label', as_index=False)['label'].transform(lambda x: x.mean())',],
+                },
+            ],
         },
 
         {


### PR DESCRIPTION
A classic pandas routine which takes a Series/column, summarises it (counts up all the values of a certain type, or takes a mean of all the numeric values) and appends the summary as a new Series/column. See related answer on [StackOverflow](https://stackoverflow.com/questions/28353577/merging-and-sum-up-several-value-counts-series-in-pandas/49678890#49678890).