### PR TITLE
Extension of toc2 in order to implement table of figures

### DIFF
--- a/src/jupyter_contrib_nbextensions/nbextensions/toc2/toc2.js
+++ b/src/jupyter_contrib_nbextensions/nbextensions/toc2/toc2.js
@@ -46,6 +46,7 @@
         toc_window_display: false,
         section_number_prefix: '',
         analyse_level: true,
+        dom_search_pattern: '[id]:header',
     };
     $.extend(true, default_cfg, metadata_settings);
 
@@ -565,7 +566,7 @@
         // excepting any header which contains an html tag with class 'tocSkip'
         // eg in ## title <a class='tocSkip'>,
         // or the ToC cell.
-        all_headers = $('.text_cell_render').find('[id]:header:not(:has(.tocSkip))');
+        all_headers = $('.text_cell_render').find(tablecfg.dom_search_pattern+':not(:has(.tocSkip))');
         var min_lvl = 1 + Number(Boolean(cfg.skip_h1_title)),
             lbl_ary = [];
         for (; min_lvl <= 6; min_lvl++) {
@@ -726,6 +727,7 @@
                 build_setting_input('sideBar', 'Display as a sidebar (otherwise as a floating window)', 'checkbox'),
                 build_setting_input('toc_window_display', 'Display ToC window/sidebar at startup', 'checkbox'),
                 build_setting_input('toc_section_display', 'Expand window/sidebar at startup', 'checkbox'),
+                build_setting_input('dom_search_pattern', 'Find headings in document based on the following dom pattern')
             ])
             .appendTo(dialog_content);
         $('<div class="modal-footer">')

--- a/src/jupyter_contrib_nbextensions/nbextensions/toc2/toc2.js
+++ b/src/jupyter_contrib_nbextensions/nbextensions/toc2/toc2.js
@@ -552,6 +552,12 @@
         // update toc element
         $("#toc").empty().append(ul);
 
+        process_table(cfg, ul, cfg);
+
+    }
+
+    var process_table = function(cfg, ul, tablecfg) {
+
         var depth = 1;
         // update all headers with id that are in rendered text cell outputs,
         // excepting any header which contains an html tag with class 'tocSkip'
@@ -583,7 +589,7 @@
             h = $(h);
             // numbered heading labels
             var num_str = incr_lbl(lbl_ary, level - 1).join('.');
-            if (cfg.number_sections) {
+            if (tablecfg.number_sections) {
                 $('<span>')
                     .text(num_str + '\u00a0\u00a0')
                     .addClass('toc-item-num')
@@ -631,7 +637,7 @@
         }
 
         // if cfg.toc_cell=true, find/add and update a toc cell in the notebook.
-        process_cell_toc(cfg, st);
+        process_cell_toc(tablecfg);
 
         // add collapse controls
         $('<i>')

--- a/src/jupyter_contrib_nbextensions/nbextensions/toc2/toc2.js
+++ b/src/jupyter_contrib_nbextensions/nbextensions/toc2/toc2.js
@@ -44,6 +44,8 @@
         toc_position: {},
         toc_section_display: true,
         toc_window_display: false,
+        section_number_prefix: '',
+        analyse_level: true,
     };
     $.extend(true, default_cfg, metadata_settings);
 
@@ -581,14 +583,18 @@
             // remove pre-existing number
             $(h).children('.toc-item-num').remove();
 
-            var level = parseInt(h.tagName.slice(1), 10) - min_lvl + 1;
-            // skip below threshold, or h1 ruled out by cfg.skip_h1_title
-            if (level < 1 || level > cfg.threshold) {
-                return;
+            if (tablecfg.analyse_level) {
+                var level = parseInt(h.tagName.slice(1), 10) - min_lvl + 1;
+                // skip below threshold, or h1 ruled out by cfg.skip_h1_title
+                if (level < 1 || level > cfg.threshold) {
+                    return;
+                }
+            } else {
+                var level = 1;
             }
             h = $(h);
             // numbered heading labels
-            var num_str = incr_lbl(lbl_ary, level - 1).join('.');
+            var num_str = tablecfg.section_number_prefix+incr_lbl(lbl_ary, level - 1).join('.');
             if (tablecfg.number_sections) {
                 $('<span>')
                     .text(num_str + '\u00a0\u00a0')
@@ -711,7 +717,9 @@
                     'The settings won\'t persist in non-live notebooks though.'),
                 build_setting_input('number_sections', 'Automatically number headings', 'checkbox'),
                 build_setting_input('skip_h1_title', 'Leave h1 items out of ToC', 'checkbox'),
+                build_setting_input('analyse_level', 'Show hierarchy in headings', 'checkbox'),
                 build_setting_input('base_numbering', 'Begin numbering at'),
+                build_setting_input('section_number_prefix', 'Add a prefix to section numbers'),
                 build_setting_input('toc_cell', 'Add notebook ToC cell', 'checkbox'),
                 build_setting_input('title_cell', 'ToC cell title'),
                 build_setting_input('title_sidebar', 'Sidebar/window title'),

--- a/src/jupyter_contrib_nbextensions/nbextensions/toc2/toc2.yaml
+++ b/src/jupyter_contrib_nbextensions/nbextensions/toc2/toc2.yaml
@@ -10,6 +10,9 @@ Parameters:
   description: Automatically number notebook's sections
   input_type: checkbox
   default: true
+- name: toc2.section_number_prefix
+  description: Add a prefix to section numbers
+  default: ''
 - name: toc2.threshold
   description: Maximum level of nested sections to display on the tables of contents
   input_type: number
@@ -23,6 +26,11 @@ Parameters:
     See the README for details, caveats and alternatives
   input_type: checkbox
   default: false
+
+- name: toc2.analyse_level
+  description: Show hierachy in headings instead of making them flat
+  input_type: checkbox
+  default: true
 
 - name: toc2.toc_cell
   description: Add a Table of Contents cell at the top of the notebook


### PR DESCRIPTION
Hello,

This is a rework of my previous pull request because the code base have since quite changed:
https://github.com/ipython-contrib/jupyter_contrib_nbextensions/pull/854

The goal of this pull request is to implement table of figures. The typical use case is to add a table on the beginning of the notebook highlightly important items that could be figures, issues, todos, recommendations ...

The current implementation add sufficient settings to replace the table of content with a table of figure. This include:
section_number_prefix: in order to add a prefix to numberized sections (eg: Figure1, Figure2 instead of 1, 2 ...)
analyse_level: in order to make the hierachy between section flat.
dom_search_pattern: in order to list arbitrary dom items instead of headings. My typical use cases are listing  `caption` for figure captions or to list tags based on a specific user defined class such as `.todo` for html items such as `<p class="todo">`.