### PR TITLE
fix cell widen bug

### DIFF
--- a/src/jupyter_contrib_nbextensions/nbextensions/toc2/toc2.js
+++ b/src/jupyter_contrib_nbextensions/nbextensions/toc2/toc2.js
@@ -238,11 +238,9 @@
         }
         if (visible_sidebar) {
             var nb_inner_w = nb_inner.outerWidth();
-            if (available_space <= nb_inner_w + sidebar_w) {
-                inner_css.marginLeft = sidebar_w + margin; // shift notebook rightward to fit the sidebar in
-                if (available_space <= nb_inner_w) {
-                    inner_css.width = available_space; // also slim notebook to fit sidebar
-                }
+            inner_css.marginLeft = sidebar_w + margin; // shift notebook rightward to fit the sidebar in
+            if (available_space <= nb_inner_w) {
+                inner_css.width = available_space; // also slim notebook to fit sidebar
             }
         }
         nb_inner.css(inner_css);


### PR DESCRIPTION
The cell was not widen as there is an unnecessary check.

While sidebar is visible and widenNotebook is enabled, the `available_space` is `nb_wrap_w - 2 * margin - sidebar_w`, and I'm not sure why `available_space` was compared to `nb_inner_w + sidebar_w`. It seems that `sidebar_w` was calced twice. This check cause the width was not automatically widen based on the page **with the default installation of jupyter**.
And I'm not sure what does the check mean, so I just removed the check and it worked fine for me.