### PR TITLE
Configure `code_prettify` extension to load custom yapf styles by default.

### DIFF
--- a/src/jupyter_contrib_nbextensions/nbextensions/code_prettify/code_prettify.js
+++ b/src/jupyter_contrib_nbextensions/nbextensions/code_prettify/code_prettify.js
@@ -26,9 +26,12 @@ define(['./kernel_exec_on_cell'], function(kernel_exec_on_cell) {
             "library": ["import json",
             "def yapf_reformat(cell_text):", 
             "    import yapf.yapflib.yapf_api",
+            "    from yapf import file_resources",
+            "    import os",
             "    import re",
+            "    style_config = file_resources.GetDefaultStyleForDir(os.getcwd())",
             "    cell_text = re.sub('^%', '#%#', cell_text, flags=re.M)",
-            "    reformated_text = yapf.yapflib.yapf_api.FormatCode(cell_text)[0]",
+            "    reformated_text = yapf.yapflib.yapf_api.FormatCode(cell_text, style_config=style_config)[0]",
             "    return re.sub('^#%#', '%', reformated_text, flags=re.M)"].join("\n"),
             "prefix": "print(json.dumps(yapf_reformat(u",
             "postfix": ")))"


### PR DESCRIPTION
**Use case**: I use a custom yapf style in my projects and I would like to configure the `code_prettify` extension to load that custom style. 

Currently, this can be done by modifying this extension's configuration, which works fine for individual modification. However, I think more sensible behavior is for the `code_prettify` extension to by default follow the same behavior described in yapf

> YAPF will search for the formatting style in the following manner:
> 1. Specified on the command line
> 2. In the [style] section of a .style.yapf file in either the current directory or one of its parent directories.
> 3. In the [yapf] section of a setup.cfg file in either the current directory or one of its parent directories.
> 4. In the ~/.config/yapf/style file in your home directory.
>
>If none of those files are found, the default style is used (PEP8).

**method**: I accomplished this by using yapf's `file_resources` submodule, which should help ensure that this extension keeps up with any potential future changes from the yapf team. 

**testing**: I've tested out this configuration using the contributing guidelines.