### PR TITLE
Update Navigation HotKeys Extension to work with command palette on new versions of jupyter 

### DIFF
--- a/src/jupyter_contrib_nbextensions/nbextensions/navigation-hotkeys/hotkeys.yaml
+++ b/src/jupyter_contrib_nbextensions/nbextensions/navigation-hotkeys/hotkeys.yaml
@@ -5,3 +5,21 @@ Link: readme.md
 Icon: icon.png
 Main: main.js
 Compatibility: 4.x, 5.x
+Parameters:
+- name: toggle_enable_edit_shortcuts
+  description: Enable all edit shortcuts
+  input_type: checkbox
+  default: true
+- name: toggle_enable_command_shortcuts
+  description: Enable all command shortcuts
+  input_type: checkbox
+  default: true
+- name: toggle_enable_esc_shortcut
+  description: Enable Esc to enter Edit mode (so Esc toggles Edit/Command mode)
+  input_type: checkbox
+  default: true
+- name: toggle_enable_enter_shortcuts
+  description: Enable Enter keys to remain in Edit mode when currently in Edit mode
+  input_type: checkbox
+  default: true
+

--- a/src/jupyter_contrib_nbextensions/nbextensions/navigation-hotkeys/main.js
+++ b/src/jupyter_contrib_nbextensions/nbextensions/navigation-hotkeys/main.js
@@ -16,256 +16,271 @@ define([
 
     // updates default params with any specified in the server's config
     var update_params = function() {
-        var config = Jupyter.notebook.config;
-        for (var key in params){
-            if (config.data.hasOwnProperty(key) ){
-                params[key] = config.data[key];
-            }
-        }
+	var config = Jupyter.notebook.config;
+	for (var key in params){
+	    if (config.data.hasOwnProperty(key) ){
+		params[key] = config.data[key];
+	    }
+	}
     };
 
     var add_command_shortcuts = {
-            'home' : {
-                help    : 'Go to top',
-                help_index : 'ga',
-                handler : function() {
-                    Jupyter.notebook.select(0);
-                    Jupyter.notebook.scroll_to_top();
-                    return false;
-                }
-            },
+	    'home' : {
+		help    : 'Go to top',
+		help_index : 'ga',
+		handler : function() {
+		    Jupyter.notebook.select(0);
+		    Jupyter.notebook.scroll_to_top();
+		    return false;
+		}
+	    },
 
-            'end' : {
-                help    : 'Go to bottom',
-                help_index : 'ga',
-                handler : function() {
-                    var ncells = Jupyter.notebook.ncells();
-                    Jupyter.notebook.select(ncells-1);
-                    Jupyter.notebook.scroll_to_bottom();
-                    return false;
-                }
-            },
+	    'end' : {
+		help    : 'Go to bottom',
+		help_index : 'ga',
+		handler : function() {
+		    var ncells = Jupyter.notebook.ncells();
+		    Jupyter.notebook.select(ncells-1);
+		    Jupyter.notebook.scroll_to_bottom();
+		    return false;
+		}
+	    },
 
-            'pageup' : {
-                help    : 'Move page up',
-                help_index : 'aa',
-                handler : function() {
-                var wh = 0.6 * $(window).height();
-                var cell = Jupyter.notebook.get_selected_cell();
-                var h = 0;
-                /* loop until we have enough cells to span the size of the notebook window (= one page) */
-                do {
-                    h += cell.element.height();
-                    Jupyter.notebook.select_prev();
-                    cell = Jupyter.notebook.get_selected_cell();
-                } while ( h < wh );
-                var cp = cell.element.position();
-                var sp = $('body').scrollTop();
-                if ( cp.top < sp) {
-                    Jupyter.notebook.scroll_to_cell(Jupyter.notebook.get_selected_index(), 0);
-                }
-                cell.focus_cell();
-                return false;
-                }
-            },
+	    'pageup' : {
+		help    : 'Move cells page up',
+		help_index : 'gu',
+		handler : function() {
+		var wh = 0.6 * $(window).height();
+		var cell = Jupyter.notebook.get_selected_cell();
+		var h = 0;
+		/* loop until we have enough cells to span the size of the notebook window (= one page) */
+		do {
+		    h += cell.element.height();
+		    Jupyter.notebook.select_prev();
+		    cell = Jupyter.notebook.get_selected_cell();
+		} while ( h < wh );
+		var cp = cell.element.position();
+		var sp = $('body').scrollTop();
+		if ( cp.top < sp) {
+		    Jupyter.notebook.scroll_to_cell(Jupyter.notebook.get_selected_index(), 0);
+		}
+		cell.focus_cell();
+		return false;
+		}
+	    },
 
-            'pagedown' : {
-                help    : 'Move page down',
-                help_index : 'aa',
-                handler : function() {
+	    'pagedown' : {
+		help    : 'Move cells page down',
+		help_index : 'gd',
+		handler : function() {
 
-                /* jump to bottom if we are already in the last cell */
-                var ncells = Jupyter.notebook.ncells();
-                if ( Jupyter.notebook.get_selected_index()+1 == ncells) {
-                    Jupyter.notebook.scroll_to_bottom();
-                    return false;
-                }
+		/* jump to bottom if we are already in the last cell */
+		var ncells = Jupyter.notebook.ncells();
+		if ( Jupyter.notebook.get_selected_index()+1 == ncells) {
+		    Jupyter.notebook.scroll_to_bottom();
+		    return false;
+		}
 
-                var wh = 0.6*$(window).height();
-                var cell = Jupyter.notebook.get_selected_cell();
-                var h = 0;
+		var wh = 0.6*$(window).height();
+		var cell = Jupyter.notebook.get_selected_cell();
+		var h = 0;
 
-                /* loop until we have enough cells to span the size of the notebook window (= one page) */
-                do {
-                    h += cell.element.height();
-                    Jupyter.notebook.select_next();
-                    cell = Jupyter.notebook.get_selected_cell();
-                } while ( h < wh );
-                cell.focus_cell();
-                return false;
-                }
-            }
+		/* loop until we have enough cells to span the size of the notebook window (= one page) */
+		do {
+		    h += cell.element.height();
+		    Jupyter.notebook.select_next();
+		    cell = Jupyter.notebook.get_selected_cell();
+		} while ( h < wh );
+		cell.focus_cell();
+		return false;
+		}
+	    }
 
-        };
+	};
 
     var add_edit_shortcuts = {
-            'alt-subtract' : {
-                help    : 'Merge cell with previous cell',
-                help_index : 'eb',
-                handler : function() {
-                    var i = Jupyter.notebook.get_selected_index();
-                    if (i > 0) {
-                        var l = Jupyter.notebook.get_cell(i-1).code_mirror.lineCount();
-                        Jupyter.notebook.merge_cell_above();
-                        Jupyter.notebook.get_selected_cell().code_mirror.setCursor(l,0);
-                        }
-                }
-            },
-            'alt-n' : {
-                help    : 'Toggle line numbers',
-                help_index : 'xy',
-                handler : function() {
-                    var cell = Jupyter.notebook.get_selected_cell();
-                    cell.toggle_line_numbers();
-                    return false;
-                }
-            },
-            'pagedown' : {
-                help    : 'Page down',
-                help_index : 'xy',
-                handler : function() {
+	    'alt-subtract' : {
+		help    : 'Merge cell with previous cell',
+		help_index : 'eb',
+		handler : function() {
+		    var i = Jupyter.notebook.get_selected_index();
+		    if (i > 0) {
+			var l = Jupyter.notebook.get_cell(i-1).code_mirror.lineCount();
+			Jupyter.notebook.merge_cell_above();
+			Jupyter.notebook.get_selected_cell().code_mirror.setCursor(l,0);
+			}
+		}
+	    },
+	    'alt-n' : {
+		help    : 'Toggle line numbers',
+		help_index : 'xy',
+		handler : function() {
+		    var cell = Jupyter.notebook.get_selected_cell();
+		    cell.toggle_line_numbers();
+		    return false;
+		}
+	    },
+	    'pagedown' : {
+		help    : 'Page down',
+		help_index : 'xy',
+		handler : function() {
 
-                    var ic = Jupyter.notebook.get_selected_index();
-                    var cells = Jupyter.notebook.get_cells();
-                    var i, h=0;
-                    for (i=0; i < ic; i ++) {
-                        h += cells[i].element.height();
-                        }
-                    var cur = cells[ic].code_mirror.getCursor();
-                    h += cells[ic].code_mirror.defaultTextHeight() * cur.line;
-                    Jupyter.notebook.element.animate({scrollTop:h}, 0);
-                    return false;
-                }
-            },
-            'pageup' : {
-                help    : 'Page up',
-                help_index : 'xy',
-                handler : function() {
+		    var ic = Jupyter.notebook.get_selected_index();
+		    var cells = Jupyter.notebook.get_cells();
+		    var i, h=0;
+		    for (i=0; i < ic; i ++) {
+			h += cells[i].element.height();
+			}
+		    var cur = cells[ic].code_mirror.getCursor();
+		    h += cells[ic].code_mirror.defaultTextHeight() * cur.line;
+		    Jupyter.notebook.element.animate({scrollTop:h}, 0);
+		    return false;
+		}
+	    },
+	    'pageup' : {
+		help    : 'Page up',
+		help_index : 'xy',
+		handler : function() {
 
-                    var ic = Jupyter.notebook.get_selected_index();
-                    var cells = Jupyter.notebook.get_cells();
-                    var i, h=0;
-                    for (i=0; i < ic; i ++) {
-                        h += cells[i].element.height();
-                        }
-                    var cur =cells[ic].code_mirror.getCursor();
-                    h += cells[ic].code_mirror.defaultTextHeight() * cur.line;
-                    Jupyter.notebook.element.animate({scrollTop:h}, 0);
-                    return false;
-                }
-            },
-            'ctrl-y' : {
-                help : 'Toggle markdown/code',
-                handler : function() {
-                    var cell = Jupyter.notebook.get_selected_cell();
-                    var cur = cell.code_mirror.getCursor();
-                    if (cell.cell_type == 'code') {
-                        Jupyter.notebook.command_mode();
-                        Jupyter.notebook.to_markdown();
-                        Jupyter.notebook.edit_mode();
-                        cell = Jupyter.notebook.get_selected_cell();
-                        cell.code_mirror.setCursor(cur);
-                    } else if (cell.cell_type == 'markdown') {
-                        Jupyter.notebook.command_mode();
-                        Jupyter.notebook.to_code();
-                        Jupyter.notebook.edit_mode();
-                        cell = Jupyter.notebook.get_selected_cell();
-                        cell.code_mirror.setCursor(cur);
-                    }
-                    return false;
-                }
-            }
-        };
+		    var ic = Jupyter.notebook.get_selected_index();
+		    var cells = Jupyter.notebook.get_cells();
+		    var i, h=0;
+		    for (i=0; i < ic; i ++) {
+			h += cells[i].element.height();
+			}
+		    var cur =cells[ic].code_mirror.getCursor();
+		    h += cells[ic].code_mirror.defaultTextHeight() * cur.line;
+		    Jupyter.notebook.element.animate({scrollTop:h}, 0);
+		    return false;
+		}
+	    },
+	    'ctrl-y' : {
+		help : 'Toggle markdown/code',
+		handler : function() {
+		    var cell = Jupyter.notebook.get_selected_cell();
+		    var cur = cell.code_mirror.getCursor();
+		    if (cell.cell_type == 'code') {
+			Jupyter.notebook.command_mode();
+			Jupyter.notebook.to_markdown();
+			Jupyter.notebook.edit_mode();
+			cell = Jupyter.notebook.get_selected_cell();
+			cell.code_mirror.setCursor(cur);
+		    } else if (cell.cell_type == 'markdown') {
+			Jupyter.notebook.command_mode();
+			Jupyter.notebook.to_code();
+			Jupyter.notebook.edit_mode();
+			cell = Jupyter.notebook.get_selected_cell();
+			cell.code_mirror.setCursor(cur);
+		    }
+		    return false;
+		}
+	    }
+	};
 
     var add_edit_enter_shortcuts = {
-            'shift-enter' : {
-                help    : 'Run cell and select next in edit mode',
-                help_index : 'bb',
-                handler : function() {
-                    Jupyter.notebook.execute_cell_and_select_below();
-                    var rendered = Jupyter.notebook.get_selected_cell().rendered;
-                    var ccell = Jupyter.notebook.get_selected_cell().cell_type;
-                    if (rendered === false || ccell === 'code') Jupyter.notebook.edit_mode();
-                    return false;
-                }
-            },
-            'ctrl-enter' : {
-                help    : 'Run selected cell stay in edit mode',
-                help_index : 'bb',
-                handler : function() {
-                    var cell = Jupyter.notebook.get_selected_cell();
-                    var mode = cell.mode;
-                    cell.execute();
-                    if (mode === "edit") Jupyter.notebook.edit_mode();
-                    return false;
-                }
-            }
+	    'shift-enter' : {
+		help    : 'Run cell and select next in edit mode',
+		help_index : 'bb',
+		handler : function() {
+		    Jupyter.notebook.execute_cell_and_select_below();
+		    var rendered = Jupyter.notebook.get_selected_cell().rendered;
+		    var ccell = Jupyter.notebook.get_selected_cell().cell_type;
+		    if (rendered === false || ccell === 'code') Jupyter.notebook.edit_mode();
+		    return false;
+		}
+	    },
+	    'ctrl-enter' : {
+		help    : 'Run selected cell stay in edit mode',
+		help_index : 'bb',
+		handler : function() {
+		    var cell = Jupyter.notebook.get_selected_cell();
+		    var mode = cell.mode;
+		    cell.execute();
+		    if (mode === "edit") Jupyter.notebook.edit_mode();
+		    return false;
+		}
+	    }
     };
 
     var initialize = function() {
 	// Update default parameters
 	update_params();
-	
+
 	var action;
 	var prefix = 'navigation_hotkeys';
 	var action_name;
 	var action_name_spaces;
 	var action_full_name;
+	var all_commands_combined = [add_command_shortcuts, add_edit_enter_shortcuts, add_edit_shortcuts];
+
+
+	// register all commands if one of the keybindings is not loaded so commands still available
+	for (let i = 0; i < all_commands_combined.length; i++){
+	    for (var key in all_commands_combined[i]){
+		// check if the property/key is defined in the object itself, not in parent
+		if (all_commands_combined[i].hasOwnProperty(key)) {
+		    action = all_commands_combined[i][key];
+		    action_name_spaces = all_commands_combined[i][key]['help'];
+		    action_name = action_name_spaces.replace(/ /g,"-").toLowerCase();
+		    action_full_name = Jupyter.keyboard_manager.actions.register(action, action_name, prefix);
+		};
+	    };
+	};
 
 	if (params.toggle_enable_command_shortcuts) {
 	    for (var key in add_command_shortcuts) {
 		// check if the property/key is defined in the object itself, not in parent
-		if (add_command_shortcuts.hasOwnProperty(key)) {           
+		if (add_command_shortcuts.hasOwnProperty(key)) {
 		    action = add_command_shortcuts[key];
 		    action_name_spaces = add_command_shortcuts[key]['help'];
 		    action_name = action_name_spaces.replace(/ /g,"-").toLowerCase();
-		    action_full_name = Jupyter.keyboard_manager.actions.register(action, action_name, prefix);
+		    action_full_name = prefix + ":" + action_name;
 		    Jupyter.keyboard_manager.command_shortcuts.add_shortcut(
 			key, action_full_name);
 		}
 	    };
 	    if (params.toggle_enable_esc_shortcut) {
 		Jupyter.keyboard_manager.command_shortcuts.add_shortcut(
-		    'Esc','jupyter-notebook:enter-edit-mode');	    
+		    'Esc','jupyter-notebook:enter-edit-mode');
 	    }
 	};
 
 	if (params.toggle_enable_edit_shortcuts) {
 	    for (var key in add_edit_shortcuts) {
 		// check if the property/key is defined in the object itself, not in parent
-		if (add_edit_shortcuts.hasOwnProperty(key)) {           
+		if (add_edit_shortcuts.hasOwnProperty(key)) {
 		    action = add_edit_shortcuts[key];
 		    action_name_spaces = add_edit_shortcuts[key]['help'];
 		    action_name = action_name_spaces.replace(/ /g,"-").toLowerCase();
-		    action_full_name = Jupyter.keyboard_manager.actions.register(action, action_name, prefix);
-		    Jupyter.keyboard_manager.edit_shortcuts.add_shortcut(key, action_full_name);	    
+		    action_full_name = prefix + ":" + action_name;
+		    Jupyter.keyboard_manager.edit_shortcuts.add_shortcut(key, action_full_name);
 		}
 	    };
 	    if (params.toggle_enable_enter_shortcuts) {
 		for (var key in add_edit_enter_shortcuts) {
 		    // check if the property/key is defined in the object itself, not in parent
-		    if (add_edit_enter_shortcuts.hasOwnProperty(key)) {           
+		    if (add_edit_enter_shortcuts.hasOwnProperty(key)) {
 			action = add_edit_enter_shortcuts[key];
 			action_name_spaces = add_edit_enter_shortcuts[key]['help'];
 			action_name = action_name_spaces.replace(/ /g,"-").toLowerCase();
-			action_full_name = Jupyter.keyboard_manager.actions.register(action, action_name, prefix);
+			action_full_name = prefix + ":" + action_name;
 			Jupyter.keyboard_manager.edit_shortcuts.add_shortcut(
 			    key, action_full_name);
 		    }
 		};
 	    };
 	    Jupyter.keyboard_manager.edit_shortcuts.add_shortcut(
-		'alt-add','jupyter-notebook:split-cell-at-cursor');	    
+		'alt-add','jupyter-notebook:split-cell-at-cursor');
 	};
-	
+
     };
 
     var load_ipython_extension = function() {
-        return Jupyter.notebook.config.loaded.then(initialize);
+	return Jupyter.notebook.config.loaded.then(initialize);
     };
 
     var extension = {
-        load_ipython_extension : load_ipython_extension
+	load_ipython_extension : load_ipython_extension
     };
     return extension;
 });

--- a/src/jupyter_contrib_nbextensions/nbextensions/navigation-hotkeys/main.js
+++ b/src/jupyter_contrib_nbextensions/nbextensions/navigation-hotkeys/main.js
@@ -7,15 +7,6 @@ define([
     "use strict";
 
     var add_command_shortcuts = {
-            'esc' : {
-                help    : 'Enter edit mode',
-                help_index : 'aa',
-                handler : function() {
-                    Jupyter.notebook.edit_mode();
-                    return false;
-                }
-            },
-
             'home' : {
                 help    : 'Go to top',
                 help_index : 'ga',
@@ -90,16 +81,6 @@ define([
         };
 
     var add_edit_shortcuts = {
-            'alt-minus' : {
-                help    : 'Split cell at cursor',
-                help_index : 'eb',
-                handler : function() {
-                    Jupyter.notebook.edit_mode();
-                    Jupyter.notebook.split_cell();
-                    Jupyter.notebook.edit_mode();
-                    return false;
-                }
-            },
             'alt-=' : {
                 help    : 'Merge cell with previous cell',
                 help_index : 'eb',

--- a/src/jupyter_contrib_nbextensions/nbextensions/navigation-hotkeys/main.js
+++ b/src/jupyter_contrib_nbextensions/nbextensions/navigation-hotkeys/main.js
@@ -3,57 +3,57 @@
 define([
     'base/js/namespace',
     'jquery'
-], function(IPython, $) {
+], function(Jupyter, $) {
     "use strict";
 
     var add_command_shortcuts = {
             'esc' : {
-                help    : 'edit mode',
+                help    : 'Enter edit mode',
                 help_index : 'aa',
                 handler : function() {
-                    IPython.notebook.edit_mode();
+                    Jupyter.notebook.edit_mode();
                     return false;
                 }
             },
 
             'home' : {
-                help    : 'go to top',
+                help    : 'Go to top',
                 help_index : 'ga',
                 handler : function() {
-                    IPython.notebook.select(0);
-                    IPython.notebook.scroll_to_top();
+                    Jupyter.notebook.select(0);
+                    Jupyter.notebook.scroll_to_top();
                     return false;
                 }
             },
 
             'end' : {
-                help    : 'go to bottom',
+                help    : 'Go to bottom',
                 help_index : 'ga',
                 handler : function() {
-                    var ncells = IPython.notebook.ncells();
-                    IPython.notebook.select(ncells-1);
-                    IPython.notebook.scroll_to_bottom();
+                    var ncells = Jupyter.notebook.ncells();
+                    Jupyter.notebook.select(ncells-1);
+                    Jupyter.notebook.scroll_to_bottom();
                     return false;
                 }
             },
 
             'pageup' : {
-                help    : 'page up',
+                help    : 'Move page up',
                 help_index : 'aa',
                 handler : function() {
                 var wh = 0.6 * $(window).height();
-                var cell = IPython.notebook.get_selected_cell();
+                var cell = Jupyter.notebook.get_selected_cell();
                 var h = 0;
                 /* loop until we have enough cells to span the size of the notebook window (= one page) */
                 do {
                     h += cell.element.height();
-                    IPython.notebook.select_prev();
-                    cell = IPython.notebook.get_selected_cell();
+                    Jupyter.notebook.select_prev();
+                    cell = Jupyter.notebook.get_selected_cell();
                 } while ( h < wh );
                 var cp = cell.element.position();
                 var sp = $('body').scrollTop();
                 if ( cp.top < sp) {
-                    IPython.notebook.scroll_to_cell(IPython.notebook.get_selected_index(), 0);
+                    Jupyter.notebook.scroll_to_cell(Jupyter.notebook.get_selected_index(), 0);
                 }
                 cell.focus_cell();
                 return false;
@@ -61,26 +61,26 @@ define([
             },
 
             'pagedown' : {
-                help    : 'page down',
+                help    : 'Move page down',
                 help_index : 'aa',
                 handler : function() {
 
                 /* jump to bottom if we are already in the last cell */
-                var ncells = IPython.notebook.ncells();
-                if ( IPython.notebook.get_selected_index()+1 == ncells) {
-                    IPython.notebook.scroll_to_bottom();
+                var ncells = Jupyter.notebook.ncells();
+                if ( Jupyter.notebook.get_selected_index()+1 == ncells) {
+                    Jupyter.notebook.scroll_to_bottom();
                     return false;
                 }
 
                 var wh = 0.6*$(window).height();
-                var cell = IPython.notebook.get_selected_cell();
+                var cell = Jupyter.notebook.get_selected_cell();
                 var h = 0;
 
                 /* loop until we have enough cells to span the size of the notebook window (= one page) */
                 do {
                     h += cell.element.height();
-                    IPython.notebook.select_next();
-                    cell = IPython.notebook.get_selected_cell();
+                    Jupyter.notebook.select_next();
+                    cell = Jupyter.notebook.get_selected_cell();
                 } while ( h < wh );
                 cell.focus_cell();
                 return false;
@@ -90,108 +90,109 @@ define([
         };
 
     var add_edit_shortcuts = {
-            'alt-add' : {
-                help    : 'split cell',
+            'alt-minus' : {
+                help    : 'Split cell at cursor',
                 help_index : 'eb',
                 handler : function() {
-                    IPython.notebook.split_cell();
-                    IPython.notebook.edit_mode();
+                    Jupyter.notebook.edit_mode();
+                    Jupyter.notebook.split_cell();
+                    Jupyter.notebook.edit_mode();
                     return false;
                 }
             },
-            'alt-subtract' : {
-                help    : 'merge cell',
+            'alt-=' : {
+                help    : 'Merge cell with previous cell',
                 help_index : 'eb',
                 handler : function() {
-                    var i = IPython.notebook.get_selected_index();
+                    var i = Jupyter.notebook.get_selected_index();
                     if (i > 0) {
-                        var l = IPython.notebook.get_cell(i-1).code_mirror.lineCount();
-                        IPython.notebook.merge_cell_above();
-                        IPython.notebook.get_selected_cell().code_mirror.setCursor(l,0);
+                        var l = Jupyter.notebook.get_cell(i-1).code_mirror.lineCount();
+                        Jupyter.notebook.merge_cell_above();
+                        Jupyter.notebook.get_selected_cell().code_mirror.setCursor(l,0);
                         }
                 }
             },
             'shift-enter' : {
-                help    : 'run cell, select next codecell',
+                help    : 'Run cell and select next in edit mode',
                 help_index : 'bb',
                 handler : function() {
-                    IPython.notebook.execute_cell_and_select_below();
-                    var rendered = IPython.notebook.get_selected_cell().rendered;
-                    var ccell = IPython.notebook.get_selected_cell().cell_type;
-                    if (rendered === false || ccell === 'code') IPython.notebook.edit_mode();
+                    Jupyter.notebook.execute_cell_and_select_below();
+                    var rendered = Jupyter.notebook.get_selected_cell().rendered;
+                    var ccell = Jupyter.notebook.get_selected_cell().cell_type;
+                    if (rendered === false || ccell === 'code') Jupyter.notebook.edit_mode();
                     return false;
                 }
             },
             'ctrl-enter' : {
-                help    : 'run cell',
+                help    : 'Run selected cell stay in edit mode',
                 help_index : 'bb',
                 handler : function() {
-                    var cell = IPython.notebook.get_selected_cell();
+                    var cell = Jupyter.notebook.get_selected_cell();
                     var mode = cell.mode;
                     cell.execute();
-                    if (mode === "edit") IPython.notebook.edit_mode();
+                    if (mode === "edit") Jupyter.notebook.edit_mode();
                     return false;
                 }
             },
             'alt-n' : {
-                help    : 'toggle line numbers',
+                help    : 'Toggle line numbers',
                 help_index : 'xy',
                 handler : function() {
-                    var cell = IPython.notebook.get_selected_cell();
+                    var cell = Jupyter.notebook.get_selected_cell();
                     cell.toggle_line_numbers();
                     return false;
                 }
             },
             'pagedown' : {
-                help    : 'page down',
+                help    : 'Page down',
                 help_index : 'xy',
                 handler : function() {
 
-                    var ic = IPython.notebook.get_selected_index();
-                    var cells = IPython.notebook.get_cells();
+                    var ic = Jupyter.notebook.get_selected_index();
+                    var cells = Jupyter.notebook.get_cells();
                     var i, h=0;
                     for (i=0; i < ic; i ++) {
                         h += cells[i].element.height();
                         }
                     var cur = cells[ic].code_mirror.getCursor();
                     h += cells[ic].code_mirror.defaultTextHeight() * cur.line;
-                    IPython.notebook.element.animate({scrollTop:h}, 0);
+                    Jupyter.notebook.element.animate({scrollTop:h}, 0);
                     return false;
                 }
             },
             'pageup' : {
-                help    : 'page down',
+                help    : 'Page up',
                 help_index : 'xy',
                 handler : function() {
 
-                    var ic = IPython.notebook.get_selected_index();
-                    var cells = IPython.notebook.get_cells();
+                    var ic = Jupyter.notebook.get_selected_index();
+                    var cells = Jupyter.notebook.get_cells();
                     var i, h=0;
                     for (i=0; i < ic; i ++) {
                         h += cells[i].element.height();
                         }
                     var cur =cells[ic].code_mirror.getCursor();
                     h += cells[ic].code_mirror.defaultTextHeight() * cur.line;
-                    IPython.notebook.element.animate({scrollTop:h}, 0);
+                    Jupyter.notebook.element.animate({scrollTop:h}, 0);
                     return false;
                 }
             },
             'ctrl-y' : {
-                help : 'toggle markdown/code',
+                help : 'Toggle markdown/code',
                 handler : function() {
-                    var cell = IPython.notebook.get_selected_cell();
+                    var cell = Jupyter.notebook.get_selected_cell();
                     var cur = cell.code_mirror.getCursor();
                     if (cell.cell_type == 'code') {
-                        IPython.notebook.command_mode();
-                        IPython.notebook.to_markdown();
-                        IPython.notebook.edit_mode();
-                        cell = IPython.notebook.get_selected_cell();
+                        Jupyter.notebook.command_mode();
+                        Jupyter.notebook.to_markdown();
+                        Jupyter.notebook.edit_mode();
+                        cell = Jupyter.notebook.get_selected_cell();
                         cell.code_mirror.setCursor(cur);
                     } else if (cell.cell_type == 'markdown') {
-                        IPython.notebook.command_mode();
-                        IPython.notebook.to_code();
-                        IPython.notebook.edit_mode();
-                        cell = IPython.notebook.get_selected_cell();
+                        Jupyter.notebook.command_mode();
+                        Jupyter.notebook.to_code();
+                        Jupyter.notebook.edit_mode();
+                        cell = Jupyter.notebook.get_selected_cell();
                         cell.code_mirror.setCursor(cur);
                     }
                     return false;
@@ -199,10 +200,38 @@ define([
             }
         };
 
+
     var load_ipython_extension = function() {
-        IPython.keyboard_manager.edit_shortcuts.add_shortcuts(add_edit_shortcuts);
-        IPython.keyboard_manager.command_shortcuts.add_shortcuts(add_command_shortcuts);
+	var action;
+	var prefix = 'navigation_hotkeys';
+	var action_name;
+	var action_name_spaces;
+	var action_full_name;
+
+	for (var key in add_command_shortcuts) {
+	    // check if the property/key is defined in the object itself, not in parent
+	    if (add_command_shortcuts.hasOwnProperty(key)) {           
+		action = add_command_shortcuts[key];
+		action_name_spaces = add_command_shortcuts[key]['help'];
+		action_name = action_name_spaces.replace(/ /g,"-").toLowerCase();
+		action_full_name = Jupyter.keyboard_manager.actions.register(action, action_name, prefix);
+		Jupyter.keyboard_manager.command_shortcuts.add_shortcut(key, action_full_name);	    
+	    }
+	};
+	for (var key in add_edit_shortcuts) {
+	    // check if the property/key is defined in the object itself, not in parent
+	    if (add_edit_shortcuts.hasOwnProperty(key)) {           
+		action = add_edit_shortcuts[key];
+		action_name_spaces = add_edit_shortcuts[key]['help'];
+		action_name = action_name_spaces.replace(/ /g,"-").toLowerCase();
+		action_full_name = Jupyter.keyboard_manager.actions.register(action, action_name, prefix);
+		Jupyter.keyboard_manager.edit_shortcuts.add_shortcut(key, action_full_name);	    
+	    }
+	};
+	
     };
+
+
     var extension = {
         load_ipython_extension : load_ipython_extension
     };

--- a/src/jupyter_contrib_nbextensions/nbextensions/navigation-hotkeys/readme.md
+++ b/src/jupyter_contrib_nbextensions/nbextensions/navigation-hotkeys/readme.md
@@ -7,10 +7,10 @@ Edit-mode hotkeys:
 
  * `pageup`        - scroll page up
  * `pagedown`      - scroll page down
- * `Alt`- `+`      - Split cell and keep cursor position
- * `Alt`- `-`      - Combine cell and keep cursor position
+ * `Alt`- `-`      - Split cell and keep cursor position
+ * `Alt`- `+`      - Combine cell and keep cursor position
  * `Alt`-`n`       - Toggle line number display in current codecell
- * `Shift`-`Enter` - Execute cell, goto next cell and stay in edit mode if next cell is a code cell or unredered markdown cell
+ * `Shift`-`Enter` - Execute cell, goto next cell and stay in edit mode if next cell is a code cell or unrendered markdown cell
  * `Ctrl`-`Enter`  - Execute cell and stay in edit mode if cell is a code cell
  * `Ctrl`-`y`      - toggle celltype between markdown and code
 

--- a/src/jupyter_contrib_nbextensions/nbextensions/navigation-hotkeys/readme.md
+++ b/src/jupyter_contrib_nbextensions/nbextensions/navigation-hotkeys/readme.md
@@ -1,21 +1,25 @@
 Navigation Hotkeys
 ==================
 
-Adds new key combinations for easier notebook navigation.
+Adds new key combinations for easier notebook navigation. (*t*) means that key or category you can toggle on/off in the settings.
 
-Edit-mode hotkeys:
+Edit-mode hotkeys (*t*):
 
  * `pageup`        - scroll page up
  * `pagedown`      - scroll page down
- * `Alt`- `+`      - Combine cell and keep cursor position
+ * `Alt`- `Add`      - Split cell and keep cursor position (+ on the keypad)
+ * `Alt`- `Subtract`      - Combine cell and keep cursor position (- on the keypad)
  * `Alt`-`n`       - Toggle line number display in current codecell
- * `Shift`-`Enter` - Execute cell, goto next cell and stay in edit mode if next cell is a code cell or unrendered markdown cell
- * `Ctrl`-`Enter`  - Execute cell and stay in edit mode if cell is a code cell
  * `Ctrl`-`y`      - toggle celltype between markdown and code
+ * `Shift`-`Enter` - (*t*) Execute cell, goto next cell and stay in edit mode if next cell is a code cell or unrendered markdown cell
+ * `Ctrl`-`Enter`  - (*t*) Execute cell and stay in edit mode if cell is a code cell
 
-Command-mode hotkeys:
+Command-mode hotkeys (*t*):
 
+* `esc`      - (*t*) toggle to edit mode
 * `home`     - Go to top of notebook
 * `end`      - Go to bottom of notebook
 * `pageup`   - scroll page up
 * `pagedown` - scroll page down
+
+

--- a/src/jupyter_contrib_nbextensions/nbextensions/navigation-hotkeys/readme.md
+++ b/src/jupyter_contrib_nbextensions/nbextensions/navigation-hotkeys/readme.md
@@ -7,7 +7,6 @@ Edit-mode hotkeys:
 
  * `pageup`        - scroll page up
  * `pagedown`      - scroll page down
- * `Alt`- `-`      - Split cell and keep cursor position
  * `Alt`- `+`      - Combine cell and keep cursor position
  * `Alt`-`n`       - Toggle line number display in current codecell
  * `Shift`-`Enter` - Execute cell, goto next cell and stay in edit mode if next cell is a code cell or unrendered markdown cell
@@ -16,7 +15,6 @@ Edit-mode hotkeys:
 
 Command-mode hotkeys:
 
-* `esc`      - toggle to edit mode
 * `home`     - Go to top of notebook
 * `end`      - Go to bottom of notebook
 * `pageup`   - scroll page up


### PR DESCRIPTION
This updates so it doesn't use `Ipython.` anymore and the new `actions.register` and `add_shortcut` commands.

If you use this in the most recent versions of jupyter, it loads the functions improperly like this:
![image](https://user-images.githubusercontent.com/43424787/50272846-66e12e00-047c-11e9-89d0-2ae04f23a5eb.png)

This has been fixed to have a proper group called `navigation_hotkeys`.

Also, second commit I removed two functions because those functions are already implemented in Jupyter as default bindings. They can be set in your `notebook.json` file, which I think is better.

#1334 Also solves this problem as this was one of the removed default bindings.