### PR TITLE
making it work for remote (public) jupyter notebook

### DIFF
--- a/src/jupyter_contrib_nbextensions/nbextensions/code_font_size/code_font_size.js
+++ b/src/jupyter_contrib_nbextensions/nbextensions/code_font_size/code_font_size.js
@@ -10,7 +10,7 @@ define([
                 var pre_style = null;
                 for(i = 0; i < document.styleSheets.length; i++){
                     //if style sheet is custom.css
-                    if(/localhost.*\/custom\/custom\.css/.test(document.styleSheets[i].href)){ 
+                    if(/.*\/custom\/custom\.css/.test(document.styleSheets[i].href)){ 
                         //pre_css now contains the style sheet custom.css
                         pre_css = document.styleSheets[i]; 
                         break;


### PR DESCRIPTION
removed 'localhost' from custom.css file path check so that it would work with remote access. Might be some other workarounds without doing this, though.