### PR TITLE
TOC2: catch headers in text in output cells created using Markdown()

### DIFF
--- a/src/jupyter_contrib_nbextensions/nbextensions/toc2/toc2.js
+++ b/src/jupyter_contrib_nbextensions/nbextensions/toc2/toc2.js
@@ -583,7 +583,7 @@
         // excepting any header which contains an html tag with class 'tocSkip'
         // eg in ## title <a class='tocSkip'>,
         // or the ToC cell.
-        all_headers = $('.text_cell_render').find('[id]:header:not(:has(.tocSkip))');
+        all_headers = $('.text_cell_render,.output_markdown').find('[id]:header:not(:has(.tocSkip))');
         var min_lvl = 1 + Number(Boolean(cfg.skip_h1_title)),
             lbl_ary = [];
         for (; min_lvl <= 6; min_lvl++) {


### PR DESCRIPTION
Make TOC2 also catch headers in text in output cells that was created using Markdown().

This allows programmatic creation of the TOC e.g. the following will now create an entry in the TOC when "run_alternative_scenario" is True

```
if run_alternative_scenario:
    display(Markdown('# Results from alt scenario')
```

Although this change makes TOC2 add headers from Markdown() text, the TOC is not automatically updated when such cells are added/changed. (You have to click the TOC2 "refresh" button to trigger an update)

Would appreciate help in getting automatic updates working!

Thanks