### PR TITLE
Add exporter name for toc2 nbconvert

### DIFF
--- a/src/jupyter_contrib_nbextensions/nbconvert_support/toc2.py
+++ b/src/jupyter_contrib_nbextensions/nbconvert_support/toc2.py
@@ -32,6 +32,9 @@ class TocExporter(HTMLExporter):
 
         jupyter nbconvert --to html_toc FILE.ipynb
     """
+    
+    export_from_notebook = "HTML + ToC"
+
 
     def _file_extension_default(self):
         return '.html'


### PR DESCRIPTION
I've found myself in an unfortunate position where a list of 6 `custom (.html)` exporters appears in the "Download As" menu; perhaps I am not alone.

(All the other converters in the same directory should probably also get `export_from_notebook` display-name attributes, but I haven't looked into what they do / what appropriate names woudl be)