### PR TITLE
Code prettify (and all KernelExecOnCells plugins) --> option to disable alert if kernel is unsupported

### DIFF
--- a/src/jupyter_contrib_nbextensions/nbextensions/code_prettify/2to3.yaml
+++ b/src/jupyter_contrib_nbextensions/nbextensions/code_prettify/2to3.yaml
@@ -38,6 +38,11 @@ Parameters:
   input_type: hotkey
   default: 'Ctrl-Shift-M'
 
+- name: 2to3.show_alerts_for_not_supported_kernel
+  description: Show alerts if the kernel is not supported
+  input_type: checkbox
+  default: false
+
 - name: 2to3.show_alerts_for_errors
   description: Show alerts for errors in the kernel converting calls
   input_type: checkbox

--- a/src/jupyter_contrib_nbextensions/nbextensions/code_prettify/README.md
+++ b/src/jupyter_contrib_nbextensions/nbextensions/code_prettify/README.md
@@ -284,7 +284,9 @@ History
 - [@artificialsoph], Jan 2018
   - updated documentation
   - changed default behavior to load custom yapf styles
-
+- [@jfbercher], April 2019
+  - corrected an issue in configs merge
+  - added an option for displaying an alert if kernel is not supported and turned it off by default (instead issue a warning in the js console). 
 
 [2to3]: README_2to3.md
 [@jcb91]: https://github.com/jcb91

--- a/src/jupyter_contrib_nbextensions/nbextensions/code_prettify/README_2to3.md
+++ b/src/jupyter_contrib_nbextensions/nbextensions/code_prettify/README_2to3.md
@@ -59,6 +59,10 @@ The options are as follows:
   Hotkey to use to transform the selected cell(s).
   Defaults to `Ctrl-L`.
 
+- `2to3.show_alerts_for_not_supported_kernel`:
+  Whether to show alerts if the kernel is not supported.
+  Defaults to `false`.
+
 - `2to3.show_alerts_for_errors`:
   Whether to show alerts for errors in the kernel calls.
   Defaults to `true`.

--- a/src/jupyter_contrib_nbextensions/nbextensions/code_prettify/README_autopep8.md
+++ b/src/jupyter_contrib_nbextensions/nbextensions/code_prettify/README_autopep8.md
@@ -65,6 +65,10 @@ The options are as follows:
   Hotkey to use to transform the selected cell(s).
   Defaults to `Alt-A`.
 
+- `autopep8.show_alerts_for_not_supported_kernel`:
+  Whether to show alerts if the kernel is not supported.
+  Defaults to `false`.
+
 - `autopep8.show_alerts_for_errors`:
   Whether to show alerts for errors in the kernel calls.
   Defaults to `true`.

--- a/src/jupyter_contrib_nbextensions/nbextensions/code_prettify/README_code_prettify.md
+++ b/src/jupyter_contrib_nbextensions/nbextensions/code_prettify/README_code_prettify.md
@@ -114,6 +114,10 @@ The options are as follows:
   Hotkey to use to transform the selected cell(s).
   Defaults to `Ctrl-L`.
 
+- `code_prettify.show_alerts_for_not_supported_kernel`:
+  Whether to show alerts if the kernel is not supported.
+  Defaults to `false`.
+
 - `code_prettify.show_alerts_for_errors`:
   Whether to show alerts for errors in the kernel calls.
   Defaults to `true`.

--- a/src/jupyter_contrib_nbextensions/nbextensions/code_prettify/README_isort.md
+++ b/src/jupyter_contrib_nbextensions/nbextensions/code_prettify/README_isort.md
@@ -25,6 +25,10 @@ All options are provided by the [KerneExecOnCells library](kernel_exec_on_cell.j
   See [fontawesome] for available icon classes.
   Defaults to `fa-sort`.
 
+- `isort.show_alerts_for_not_supported_kernel`:
+  Whether to show alerts if the kernel is not supported.
+  Defaults to `false`.
+
 - `isort.show_alerts_for_errors`: Whether to show alerts for errors in the kernel calls. Defaults to `false`.
 
 - `isort.button_label`: Toolbar button label text. Also used in the actions' help text. Defaults to `Sort imports with isort`.

--- a/src/jupyter_contrib_nbextensions/nbextensions/code_prettify/autopep8.yaml
+++ b/src/jupyter_contrib_nbextensions/nbextensions/code_prettify/autopep8.yaml
@@ -41,6 +41,11 @@ Parameters:
   input_type: hotkey
   default: 'Alt-Shift-A'
 
+- name: autopep8.show_alerts_for_not_supported_kernel
+  description: Show alerts if the kernel is not supported
+  input_type: checkbox
+  default: false
+
 - name: autopep8.show_alerts_for_errors
   description: Show alerts for errors in the kernel prettifying calls
   input_type: checkbox

--- a/src/jupyter_contrib_nbextensions/nbextensions/code_prettify/code_prettify.yaml
+++ b/src/jupyter_contrib_nbextensions/nbextensions/code_prettify/code_prettify.yaml
@@ -41,6 +41,11 @@ Parameters:
   input_type: hotkey
   default: 'Ctrl-Shift-L'
 
+- name: code_prettify.show_alerts_for_not_supported_kernel
+  description: Show alerts if the kernel is not supported
+  input_type: checkbox
+  default: false
+
 - name: code_prettify.show_alerts_for_errors
   description: Show alerts for errors in the kernel prettifying calls
   input_type: checkbox

--- a/src/jupyter_contrib_nbextensions/nbextensions/code_prettify/kernel_exec_on_cell.js
+++ b/src/jupyter_contrib_nbextensions/nbextensions/code_prettify/kernel_exec_on_cell.js
@@ -48,7 +48,7 @@ define([
         };
         // extend a new object, to avoid interference with other nbextensions
         // derived from the same base class
-        this.cfg = $.extend(true, {}, cfg, default_cfg);
+        this.cfg = $.extend(true, {}, default_cfg, cfg);
         // set default json string, will later be updated from config
         // before it is parsed into an object
         this.cfg.kernel_config_map_json = JSON.stringify(this.cfg.kernel_config_map);

--- a/src/jupyter_contrib_nbextensions/nbextensions/code_prettify/kernel_exec_on_cell.js
+++ b/src/jupyter_contrib_nbextensions/nbextensions/code_prettify/kernel_exec_on_cell.js
@@ -39,6 +39,7 @@ define([
             },
             register_hotkey: true,
             show_alerts_for_errors: true,
+            show_alerts_for_not_supported_kernel: false,
             button_icon: 'fa-legal',
             button_label: mod_name,
             kbd_shortcut_text: mod_name,
@@ -258,10 +259,16 @@ define([
         var kernel_config = this.cfg.kernel_config_map[kernelLanguage];
         if (kernel_config === undefined) {
             $('#' + this.mod_name + '_button').remove();
-            alert(this.mod_log_prefix + " Sorry, can't use kernel language " + kernelLanguage + ".\n" +
+            var err = this.mod_log_prefix + " Sorry, can't use kernel language " + kernelLanguage + ".\n" +
                 "Configurations are currently only defined for the following languages:\n" +
                 Object.keys(this.cfg.kernel_config_map).join(', ') + "\n" +
-                "See readme for more details.");
+                "See readme for more details."
+            if (this.cfg.show_alerts_for_not_supported_kernel) {
+                        alert(err);
+                                                }
+            else {
+                        console.error(err);
+                 }            
             // also remove keyboard shortcuts
             if (this.cfg.register_hotkey) {
                 try {


### PR DESCRIPTION

 - added an option for displaying an alert if kernel is not supported and turned it off by default (instead issue a warning in the js console). This addresses #1386 @kafonek   @riordan
  - also, in passing, corrected an issue in configs merge. 