### PR TITLE
[toc2] Updates

### DIFF
--- a/src/jupyter_contrib_nbextensions/nbconvert_support/toc2.py
+++ b/src/jupyter_contrib_nbextensions/nbconvert_support/toc2.py
@@ -49,7 +49,7 @@ class TocExporter(HTMLExporter):
 
     @property
     def default_config(self):
-        c = Config({'ExtractOutputPreprocessor': {'enabled': True}})
+        c = Config({'ExtractOutputPreprocessor': {'enabled': False}})
         #  import here to avoid circular import
         from jupyter_contrib_nbextensions.nbconvert_support import (
             templates_directory)

--- a/src/jupyter_contrib_nbextensions/nbextensions/toc2/README.md
+++ b/src/jupyter_contrib_nbextensions/nbextensions/toc2/README.md
@@ -142,3 +142,8 @@ This option requires the IPython kernel and is not present with other kernels.
   + constrain draggable toc to the body
   + various bits of cleanup
   + add settings dialog for per-notebook metadata-stored settings
+- @jfbercher Feb 2018, Option to define a number to begin numbering with.
+- @jcb91 March 2018, Add controls for all per-notebook metadata options
+- @jfbercher December 2018, toc2 history. Moves into the toc2 history of jumps into the notebook, using the forward-back browser buttons.
+- @zthxxx, April 2018, fix toc2.js load failed with working in non-live notebook (with navigation menu enabled)
+- @jfbercher April 2018, Some export tuning 

--- a/src/jupyter_contrib_nbextensions/templates/toc2.tpl
+++ b/src/jupyter_contrib_nbextensions/templates/toc2.tpl
@@ -18,7 +18,7 @@
 $( document ).ready(function(){
 
             var cfg = {{ nb.get('metadata', {}).get('toc', {})|tojson|safe }};
-
+            cfg.navigate_menu=false;
             // fire the main function with these parameters
             require(['nbextensions/toc2/toc2'], function (toc2) {
                 toc2.table_of_contents(cfg);


### PR DESCRIPTION
- Complement fix for issue #1402 by disabling Navigate menu in toc2 template (Navigate menu  cannot be shown in non-livenotebook conditions)
- Changed toc2.py exporter to embed images in the html output, rather than extract them
- Updated history