### PR TITLE
[varInspector] updated var_list.py to address #1275

### DIFF
--- a/src/jupyter_contrib_nbextensions/nbextensions/varInspector/var_list.py
+++ b/src/jupyter_contrib_nbextensions/nbextensions/varInspector/var_list.py
@@ -3,16 +3,14 @@ from sys import getsizeof
 
 from IPython import get_ipython
 from IPython.core.magics.namespace import NamespaceMagics
-
 _nms = NamespaceMagics()
 _Jupyter = get_ipython()
 _nms.shell = _Jupyter.kernel.shell
 
 try:
-    import numpy as np  # noqa: F401
+    import numpy as np
 except ImportError:
-    pass
-
+    pass    
 
 def _getsizeof(x):
     # return the size of variable x. Amended version of sys.getsizeof
@@ -24,22 +22,39 @@ def _getsizeof(x):
     else:
         return getsizeof(x)
 
-
 def _getshapeof(x):
-    # returns the shape of x if it has one
-    # returns None otherwise - might want to return an empty string for an empty collum
+    #returns the shape of x if it has one
+    #returns None otherwise - might want to return an empty string for an empty column
     try:
         return x.shape
-    except AttributeError:  # x does not have a shape
+    except AttributeError: #x does not have a shape
         return None
 
+def _getcontentof(x):
+    length = 150
+    if type(x).__name__ == 'DataFrame':
+        colnames = ', '.join(x.columns.map(str))
+        content = "Column names: %s" % colnames
+    elif type(x).__name__ == 'Series':
+        content = "Series [%d rows]" % x.shape
+    elif type(x).__name__ == 'ndarray':
+        content = x.__repr__()
+    else:
+        if hasattr(x, '__len__'):
+            if len(x) > length:
+                content = str(x[:length])
+        else:
+            content = str(x)
+        if len(content) > 150:
+            return content[:150] + " ..."
+    return content
 
 def var_dic_list():
     types_to_exclude = ['module', 'function', 'builtin_function_or_method',
                         'instance', '_Feature', 'type', 'ufunc']
     values = _nms.who_ls()
-    vardic = [{'varName': v, 'varType': type(eval(v)).__name__, 'varSize': str(_getsizeof(eval(v))), 'varShape': str(_getshapeof(eval(v))) if _getshapeof(eval(v)) else '', 'varContent': str(eval(v))[:200]}  # noqa
-
+    vardic = [{'varName': v, 'varType': type(eval(v)).__name__, 'varSize': str(_getsizeof(eval(v))), 'varShape': str(_getshapeof(eval(v))) if _getshapeof(eval(v)) else '', 'varContent': _getcontentof(eval(v)) }  # noqa
+    
     for v in values if (v not in ['_html', '_nms', 'NamespaceMagics', '_Jupyter']) & (type(eval(v)).__name__ not in types_to_exclude)] # noqa 
     return json.dumps(vardic)
 


### PR DESCRIPTION
Tentative fix to #1275 
As analyzed by @babymastodon for large variables, printing the beginning of content of the variable using str(var) [:200] still converts the full content to str even though only some characters are printed. For very large variables, this causes a slow down of the notebook each time varInspector is called. 
The fix consists in testing if the variable has a length property and then extracts the first elements of the variable before converting it to string. 
Tested here with a 2Gb file read as a binary variable without noticing any slow down. 
Further tests welcome. 
