### PR TITLE
New extension to duplicate/delete lines

### DIFF
--- a/src/jupyter_contrib_nbextensions/nbextensions/line_edit/README.md
+++ b/src/jupyter_contrib_nbextensions/nbextensions/line_edit/README.md
@@ -1,0 +1,7 @@
+# Line Edit
+
+Keyboard shortcuts to duplicate a line, and delete a line. Taken from http://stackoverflow.com/a/40505055/6003870.
+
+Keyboard shortcuts: 
+- *Ctrl+Alt+D* : duplicate line
+- *Ctrl+Alt+K* : delete line

--- a/src/jupyter_contrib_nbextensions/nbextensions/line_edit/line_edit.yaml
+++ b/src/jupyter_contrib_nbextensions/nbextensions/line_edit/line_edit.yaml
@@ -1,0 +1,6 @@
+Type: Jupyter Notebook Extension
+Compatibility: 5.x
+Name: Line Edit
+Main: main.js
+Link: README.md
+Description: Duplicate and delete lines using Ctrl+Alt+D and Ctrl+Alt+K.

--- a/src/jupyter_contrib_nbextensions/nbextensions/line_edit/main.js
+++ b/src/jupyter_contrib_nbextensions/nbextensions/line_edit/main.js
@@ -1,0 +1,88 @@
+define([
+    'base/js/namespace',
+    'codemirror/lib/codemirror'
+], function(Jupyter, CodeMirror) {
+    "use strict";
+
+    var prefix = 'auto';
+
+    var action_duplicateLine = Jupyter.keyboard_manager.actions.register(
+        {
+            icon: 'fa-comment-o',
+            help: 'Duplicate Line',
+            help_index: 'ec',
+            id: 'duplicate-line',
+            handler: duplicateLine
+        },
+        'duplicate-line',
+        prefix
+    );
+
+    var action_deleteLine = Jupyter.keyboard_manager.actions.register(
+        {
+            icon: 'fa-comment-o',
+            help: 'Delete Line',
+            help_index: 'ec',
+            id: 'delete-line',
+            handler: deleteLine
+        },
+        'delete-line',
+        prefix
+    );
+
+    var edit_mode_shortcuts = {
+        'Ctrl-Alt-d': action_duplicateLine,
+        'Ctrl-Alt-k': action_deleteLine
+    };
+
+    var load_extension = function() {
+        Jupyter.keyboard_manager.edit_shortcuts.add_shortcuts(edit_mode_shortcuts);
+        console.log("[line_edit] loaded");
+    };
+
+    function duplicateLine() {
+        var cm = Jupyter.notebook.get_selected_cell().code_mirror
+
+        // get current cursor position
+        var current_cursor = cm.doc.getCursor();
+
+        // First go to end of line, to avoid the problem where if cursor was at start
+        // of indented text, goLineStartSmart would go to very beginning of line,
+        // and so we'd get unwanted tabs/spaces in the getRange function.
+        CodeMirror.commands.goLineEnd(cm);
+        // now we can safely call goLineStartSmart
+        CodeMirror.commands.goLineStartSmart(cm);
+        var start_cursor = cm.doc.getCursor();
+        var start = {'line': start_cursor.line, 'ch': start_cursor.ch};
+
+        // go to the end of line
+        CodeMirror.commands.goLineEnd(cm);
+        var end_cursor = cm.doc.getCursor();
+        var end = {'line': end_cursor.line, 'ch': end_cursor.ch};
+
+        // get content
+        var line_content = cm.doc.getRange(start, end);
+
+        // make a break for a new line
+        CodeMirror.commands.newlineAndIndent(cm);
+
+        // filled a content of the new line content from line above it
+        cm.doc.replaceSelection(line_content);
+
+        // restore position cursor on the new line
+        cm.doc.setCursor(current_cursor.line + 1, current_cursor.ch);
+    }
+
+    function deleteLine() {
+        var cm = Jupyter.notebook.get_selected_cell().code_mirror
+
+        // get current cursor position
+        var current_cursor = cm.doc.getCursor();
+        CodeMirror.commands.deleteLine(cm);
+    }
+
+    return {
+        load_ipython_extension: load_extension,
+    };
+
+});


### PR DESCRIPTION
This is a small extension intended to enhance Jupyter Notebook as a text editor. Two new commands are added for edit mode. The keyboard commands are chosen for similarity with Sublime Text and Atom (Ctrl-Shift-D cannot be used as that is the default for adding a bookmark to Chrome).

- `duplicate line` : `Ctrl-Alt-D` : duplicates the current line
- `delete line` : `Ctrl-Alt-K` :  deletes the current line

Credit to http://stackoverflow.com/a/40505055/6003870 for the basic code for this.