### PR TITLE
[toc2] New option to lock the sidebar and disable dragging it as a floating window

### DIFF
--- a/src/jupyter_contrib_nbextensions/nbconvert_support/toc2.py
+++ b/src/jupyter_contrib_nbextensions/nbconvert_support/toc2.py
@@ -1,7 +1,7 @@
 """Toc2 exporter class, TocExporter"""
 
 # -----------------------------------------------------------------------------
-# Copyright (c) 2016, the IPython IPython-Contrib Development Team.
+# Copyright (c) 2016-2019, the IPython IPython-Contrib Development Team.
 #
 # Distributed under the terms of the Modified BSD License.
 #

--- a/src/jupyter_contrib_nbextensions/nbextensions/toc2/README.md
+++ b/src/jupyter_contrib_nbextensions/nbextensions/toc2/README.md
@@ -43,6 +43,7 @@ facility, included with
 Configurable options include:
 
 - Display Table of Contents as a sidebar (otherwise as a floating window; default: true)
+- Lock sidebar on the left - disable drag as a floating window (default: false)
 - Title of the sidebar/window (default: `Contents`)
 - The maximum depth of headers to display on toc (with a default of 4)
 - The state of the toc cell (default: false, ie not present)
@@ -145,5 +146,6 @@ This option requires the IPython kernel and is not present with other kernels.
 - @jfbercher Feb 2018, Option to define a number to begin numbering with.
 - @jcb91 March 2018, Add controls for all per-notebook metadata options
 - @jfbercher December 2018, toc2 history. Moves into the toc2 history of jumps into the notebook, using the forward-back browser buttons.
-- @zthxxx, April 2018, fix toc2.js load failed with working in non-live notebook (with navigation menu enabled)
-- @jfbercher April 2018, Some export tuning 
+- @zthxxx, April 2019, fix toc2.js load failed with working in non-live notebook (with navigation menu enabled)
+- @jfbercher April 2019, Some export tuning 
+- @jfbercher May 2019, Option to lock sidebar

--- a/src/jupyter_contrib_nbextensions/nbextensions/toc2/toc2.js
+++ b/src/jupyter_contrib_nbextensions/nbextensions/toc2/toc2.js
@@ -40,6 +40,7 @@
         base_numbering: 1,
         title_cell: 'Table of Contents',
         title_sidebar: 'Contents',
+        lock_sidebar: false,
         toc_cell: false,
         toc_position: {},
         toc_section_display: true,
@@ -364,6 +365,11 @@
 
         // enable dragging and save position on stop moving
         toc_wrapper.draggable({
+            start: function(event, ui) {
+                 // disable drag if sidebar exists and lock is true
+                 if (cfg.sideBar && cfg.lock_sidebar){
+                    event.preventDefault();} 
+                },
             drag: function(event, ui) {
                 var make_sidebar = ui.position.left < 20; // 20 is snapTolerance
                 if (make_sidebar) {
@@ -741,6 +747,7 @@
                 build_setting_input('title_cell', 'ToC cell title'),
                 build_setting_input('title_sidebar', 'Sidebar/window title'),
                 build_setting_input('sideBar', 'Display as a sidebar (otherwise as a floating window)', 'checkbox'),
+                build_setting_input('lock_sidebar', 'Lock sidebar', 'checkbox'),
                 build_setting_input('toc_window_display', 'Display ToC window/sidebar at startup', 'checkbox'),
                 build_setting_input('toc_section_display', 'Expand window/sidebar at startup', 'checkbox'),
             ])

--- a/src/jupyter_contrib_nbextensions/nbextensions/toc2/toc2.yaml
+++ b/src/jupyter_contrib_nbextensions/nbextensions/toc2/toc2.yaml
@@ -37,6 +37,11 @@ Parameters:
   description: Default title used for ToC sidebar/window (can also be set per-notebook)
   default: 'Contents'
 
+- name: toc2.lock_sidebar
+  description: Lock sidebar, ie do not enable moving it as a floating window (can also be set per-notebook)
+  input_type: checkbox
+  default: false
+
 - name: toc2.toc_window_display
   description: Display toc window/sidebar at startup
   input_type: checkbox


### PR DESCRIPTION
Add an option to lock the sidebar (option editable in the general toc2 config for the default behaviour -- default false, and via the toc2-parameters window for a config per notebook). This is also works on exported html with toc2 option. Hope this helps. 
Addresses #1289 