### PR TITLE
Add python 2/3 trove classifiers

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -114,6 +114,9 @@ if you encounter any problems, and create a new issue if needed!
             'Operating System :: OS Independent',
             'Programming Language :: JavaScript',
             'Programming Language :: Python',
+            'Programming Language :: Python :: 2.7',
+            'Programming Language :: Python :: 3',
+            'Programming Language :: Python :: 3.6',
             'Topic :: Utilities',
         ],
     )


### PR DESCRIPTION
Clearly identify this project as supporting python 2 and 3.
This is useful for utility programs like [caniusepython3](https://github.com/brettcannon/caniusepython3#how-do-you-tell-if-a-project-has-been-ported-to-python-3).