### PR TITLE
Update Python-Markdown readme to reflect optional changes to notebook_config

### DIFF
--- a/src/jupyter_contrib_nbextensions/nbextensions/python-markdown/readme.md
+++ b/src/jupyter_contrib_nbextensions/nbextensions/python-markdown/readme.md
@@ -67,6 +67,18 @@ c = get_config()
 c.Exporter.preprocessors = ['pre_pymarkdown.PyMarkdownPreprocessor']
 ```
 
+If you intend to use the drop-down menus in the Jupyter Notebook interface, then you need to add the content below to to the `jupyter_notebook_config.json` file (adding it at the correct level if other content already exists).
+
+```
+{
+    "Exporter": {
+        "preprocessors": [
+          "jupyter_contrib_nbextensions.nbconvert_support.pre_pymarkdown.PyMarkdownPreprocessor"
+        ]
+    }
+}
+```
+
 
 Internals
 ---------


### PR DESCRIPTION
@juhasch, I have added your insight from #585 into the README for the extension. Was burnt by this because I forgot the distinction between nbconvert and notebook config.

It looks like the start install does not add the pre-processor to the notebook exporter setting. So this reminds the user they need to add that if they want this to work.