### PR TITLE
Add the terminal command for enabling hinterland

### DIFF
--- a/src/jupyter_contrib_nbextensions/nbextensions/hinterland/README.md
+++ b/src/jupyter_contrib_nbextensions/nbextensions/hinterland/README.md
@@ -8,6 +8,11 @@ The nbextension adds an item to the help menu to turn auto-hinting on and off,
 and offers some options for configuration:
 
 
+Enabling
+-------
+* jupyter nbextension enable hinterland/hinterland
+
+
 Options
 -------
 


### PR DESCRIPTION
The documentation says 

`jupyter nbextension enable extension/main` is the appropriate way of enabling an extension.

`jupyter nbextension enable hinterland/hinterland` is the way of enabling hinterland.