### PR TITLE
Fix for issue #1461

### DIFF
--- a/src/jupyter_contrib_nbextensions/nbextensions/zenmode/main.css
+++ b/src/jupyter_contrib_nbextensions/nbextensions/zenmode/main.css
@@ -14,6 +14,7 @@
     display: none !important;
 }
 
+/*
 #notebook-container {
     background-color: rgba(255, 255, 255, 0.8);
 }
@@ -22,7 +23,6 @@
     background-color: rgb(255, 255, 255);
 }
 
-/*
 .CodeMirror {
     background: #F8FCCF;
 }

--- a/src/jupyter_contrib_nbextensions/nbextensions/zenmode/main.css
+++ b/src/jupyter_contrib_nbextensions/nbextensions/zenmode/main.css
@@ -14,11 +14,11 @@
     display: none !important;
 }
 
-/*
 #notebook-container {
-    background-color: rgba(255, 255, 255, 0.8);
+    background-color: rgba(255, 255, 255, 0);
 }
 
+/*
 .cell {
     background-color: rgb(255, 255, 255);
 }

--- a/src/jupyter_contrib_nbextensions/nbextensions/zenmode/main.js
+++ b/src/jupyter_contrib_nbextensions/nbextensions/zenmode/main.js
@@ -1,6 +1,6 @@
 /**
 * ----------------------------------------------------------------------------
-* Copyright (c) 2013 - DamiÃ¡n Avila
+* Copyright (c) 2013 - Damián Avila
 * Copyright (c) 2015 - Joshua Cooke Barnes (jcb91)
 *
 * Distributed under the terms of the Modified BSD License.
@@ -62,12 +62,12 @@ define([
 
 
             // Remove zenmode css settings only when changes were made.
-	    if (backgrounds.length != 0) {
-		$('body').css({
-		    'background-image': 'none'
-		})
-	    }
-	    
+            if (backgrounds.length != 0) {
+                $('body').css({
+                    'background-image': 'none'
+                })
+            }
+            
             // This should be changed at some point in the future to preserve non-zenmode visibility settings
             $(menu_pattern).toggle(true);
             $(header_pattern).toggle(true);
@@ -88,20 +88,20 @@ define([
                 background = requirejs.toUrl("./images/" + background);
             }
 
-	    // Apply zenmode css when there are images to be used.
-	    if (backgrounds.length != 0) {
-		$('body').css({
-		    'background-image': 'url(' + background + ')',
-		    'background-repeat': 'no-repeat',
-		    'background-position': 'center center',
-		    'background-attachment': 'fixed',
-		    '-webkit-background-size': 'cover',
-		    '-moz-background-size': 'cover',
-		    '-o-background-size': 'cover',
-		    'background-size': 'cover'
-		});
-	    }
-	    
+            // Apply zenmode css when there are images to be used.
+            if (backgrounds.length != 0) {
+                $('body').css({
+                    'background-image': 'url(' + background + ')',
+                    'background-repeat': 'no-repeat',
+                    'background-position': 'center center',
+                    'background-attachment': 'fixed',
+                    '-webkit-background-size': 'cover',
+                    '-moz-background-size': 'cover',
+                    '-o-background-size': 'cover',
+                    'background-size': 'cover'
+                });
+            }
+
             if (hide_menubar)
                 {$(menu_pattern).toggle(false);}
             if (hide_header)

--- a/src/jupyter_contrib_nbextensions/nbextensions/zenmode/main.js
+++ b/src/jupyter_contrib_nbextensions/nbextensions/zenmode/main.js
@@ -1,6 +1,6 @@
 /**
 * ----------------------------------------------------------------------------
-* Copyright (c) 2013 - Damián Avila
+* Copyright (c) 2013 - DamiÃ¡n Avila
 * Copyright (c) 2015 - Joshua Cooke Barnes (jcb91)
 *
 * Distributed under the terms of the Modified BSD License.
@@ -60,10 +60,14 @@ define([
             $('#zenmode-toggle-btn .fa').removeClass("fa-rebel").addClass("fa-empire");
             $('#zenmodecss').remove();
 
-            // retrieve and reapply old bg css settings
-            var oldBg = $('body').attr(oldBgAttrName) || "#ffffff";
-            $('body').css({"background": oldBg});
 
+            // Remove zenmode css settings only when changes were made.
+	    if (backgrounds.length != 0) {
+		$('body').css({
+		    'background-image': 'none'
+		})
+	    }
+	    
             // This should be changed at some point in the future to preserve non-zenmode visibility settings
             $(menu_pattern).toggle(true);
             $(header_pattern).toggle(true);
@@ -84,16 +88,20 @@ define([
                 background = requirejs.toUrl("./images/" + background);
             }
 
-            // save old bg css, then apply new
-            $('body').attr(oldBgAttrName, ($('body').get(0).style.background || ""));
-            $('body').css({
-                'background': 'url(' + background + ') no-repeat center center fixed',
-                '-webkit-background-size': 'cover',
-                '-moz-background-size': 'cover',
-                '-o-background-size': 'cover',
-                'background-size': 'cover'
-            });
-
+	    // Apply zenmode css when there are images to be used.
+	    if (backgrounds.length != 0) {
+		$('body').css({
+		    'background-image': 'url(' + background + ')',
+		    'background-repeat': 'no-repeat',
+		    'background-position': 'center center',
+		    'background-attachment': 'fixed',
+		    '-webkit-background-size': 'cover',
+		    '-moz-background-size': 'cover',
+		    '-o-background-size': 'cover',
+		    'background-size': 'cover'
+		});
+	    }
+	    
             if (hide_menubar)
                 {$(menu_pattern).toggle(false);}
             if (hide_header)


### PR DESCRIPTION
Fixed the gray background for the notebook-container problem by making the opacity 0. Commented out cell CSS to make it more suitable to the specified theme.

When zenmode it toggled on, the old background is no longer stored and nothing is stored in it anyway, and the same properties are stored in respective properties.
When zenmode is toggled off, the image is removed and nothing is changed.

Since we are making notebook-container transparent when toggling zenmode on and not changing it back when toggling zenmode off, this will not completely restore the look of the original theme for some themes where the notebook-container has a different background than the normal background.