### PR TITLE
Fix duplicate call of extension "init_cell"

### DIFF
--- a/src/jupyter_contrib_nbextensions/nbextensions/init_cell/main.js
+++ b/src/jupyter_contrib_nbextensions/nbextensions/init_cell/main.js
@@ -147,8 +147,10 @@ define([
             // kernel is already ready
             run_init_cells();
         }
-        // whenever a (new) kernel  becomes ready, run all initialization cells
-        events.on('kernel_ready.Kernel', run_init_cells);
+        else {
+            // whenever a (new) kernel  becomes ready, run all initialization cells
+            events.on('kernel_ready.Kernel', run_init_cells);
+        }
     }
 
     return {


### PR DESCRIPTION
There exists a possibility of calling function `run_init_cells()` twice on function `run_init_cells_asap()`.
Kernel exists only as two cases: (1) Kernel is already ready, and (2) Kernel is not yet ready, and in both cases, `run_init_cells()` should be called only once.
On case (1), there is no need to hook an event on `kernel_ready`, as cells are already initialized.
If the event hook exists, in some specific cases, `run_init_cells()` is called twice, due to racing conditions.