### PR TITLE
Fix Link for language list for nbTranslate readthedocs

### DIFF
--- a/src/jupyter_contrib_nbextensions/nbextensions/nbTranslate/README.md
+++ b/src/jupyter_contrib_nbextensions/nbextensions/nbTranslate/README.md
@@ -35,7 +35,7 @@ It is possible to extract one language from the multilanguage notebook. An expor
 ```
 jupyter nbconvert --to selectLanguage --NotebookLangExporter.language=lang  FILE.ipynb 
 ```
-where the `lang` parameter denotes a valid language abbreviation e.g. en, fr, ar, sp. See the full list <a href='languages.js'> here.</a>
+where the `lang` parameter denotes a valid language abbreviation e.g. en, fr, ar, sp. See the full list <a href='https://github.com/ipython-contrib/jupyter_contrib_nbextensions/blob/master/src/jupyter_contrib_nbextensions/nbextensions/nbTranslate/languages.js'> here.</a>
 
 
 Installation


### PR DESCRIPTION
On github relative path link to languages.js works fine but it leads to page does not exist when clicked via docs site like [this](https://jupyter-contrib-nbextensions.readthedocs.io/en/latest/nbextensions/nbTranslate/languages.js)  
Replacing it with absolute path should work for both.