### PR TITLE
Extensions Not Loading for Large Notebooks

### DIFF
--- a/docs/source/troubleshooting.md
+++ b/docs/source/troubleshooting.md
@@ -15,7 +15,7 @@ for details.
 To mitigate this issue, you can increase the timeout for requirejs by adding it in your custom.js:
 
         // default is 30s, increase to 1 minute
-        window.requirejs.config({waitseconds: 60});
+        window.requirejs.config({waitSeconds: 60});
         
 You can find details of where to find/create a custom.js file at the notebook documentation
 about [custom.js](http://jupyter-notebook.readthedocs.io/en/latest/examples/Notebook/JavaScript%20Notebook%20Extensions.html#custom.js). 


### PR DESCRIPTION
'waitseconds' is changed to 'waitSeconds' following this official usage example:
https://requirejs.org/docs/api.html#config
Regarding this is based on the issue [#1195](https://github.com/ipython-contrib/jupyter_contrib_nbextensions/issues/1195).
by the following [comment](https://github.com/ipython-contrib/jupyter_contrib_nbextensions/issues/1195#issuecomment-357756819)

By mistake, I missed this comment and seem to work around this by myself for couple of hours.