### PR TITLE
replace template_path with template_paths

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 # http://travis-ci.org/#!/ipython-contrib/jupyter_contrib_nbextensions
 language: python
-dist: trusty # required for pandoc>1.9.1
+dist: xenial
 sudo: false
 addons:
   apt_packages:
@@ -14,46 +14,37 @@ addons:
 matrix:
   fast_finish: true
   # Use the built-in venv for linux builds
-  # 3.5 as it isn't installed by default. Let tox handle other versions.
+  # 3.6 as it isn't installed by default. Let tox handle other versions.
   include:
     # packaging sanity check
     - os: linux
-      python: '3.6'
+      python: '3.8'
       env: TOXENV=check
     # python linting
     - os: linux
-      python: '3.6'
+      python: '3.8'
       env: TOXENV=lint
     # check docs build correctly
     - os: linux
-      python: '3.6'
+      python: '3.8'
       env: TOXENV=docs_build
     # check docs links
     - os: linux
-      python: '3.6'
+      python: '3.8'
       env: TOXENV=docs_linkcheck
     # check that conda build/install works
     - os: linux
-      python: '3.6'
+      python: '3.8'
       env: TOXENV=condarecipe
     # linux, various python and notebook versions
     - os: linux
-      python: '2.7'
-      env: TOXENV=py27-notebook
+      python: '3.8'
+      env: TOXENV=py38-notebook60
     - os: linux
-      python: '3.6'
-      env: TOXENV=py36-notebook54
+      python: '3.8'
+      env: TOXENV=py38-notebook
     - os: linux
-      python: '3.6'
-      env: TOXENV=py36-notebook55
-    - os: linux
-      python: '3.6'
-      env: TOXENV=py36-notebook44
-    - os: linux
-      python: '3.6'
-      env: TOXENV=py36-notebook
-    - os: linux
-      python: '3.6'
+      python: '3.8'
       env: TOXENV=appveyorartifacts
   allow_failures:
     - env: TOXENV=appveyorartifacts

--- a/.travis.yml
+++ b/.travis.yml
@@ -58,10 +58,9 @@ env:
     - LD_PRELOAD=/lib/x86_64-linux-gnu/libSegFault.so
     - SEGFAULT_SIGNALS=all
 before_install:
-  # - uname -a
-  # - id -un
-  # - id -Gn
-  - python --version
+  - uname -a
+  - id -un
+  - id -Gn
   - pip install -U pip
   # stuff for conda recipe
   - 'if [[ ${TOXENV} == "condarecipe" ]]; then wget https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -O miniconda.sh; fi'

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,37 +14,37 @@ addons:
 matrix:
   fast_finish: true
   # Use the built-in venv for linux builds
-  # 3.6 as it isn't installed by default. Let tox handle other versions.
+  # 3.5 as it isn't installed by default. Let tox handle other versions.
   include:
     # packaging sanity check
     - os: linux
-      python: '3.8'
+      python: '3.7'
       env: TOXENV=check
     # python linting
     - os: linux
-      python: '3.8'
+      python: '3.7'
       env: TOXENV=lint
     # check docs build correctly
     - os: linux
-      python: '3.8'
+      python: '3.7'
       env: TOXENV=docs_build
     # check docs links
     - os: linux
-      python: '3.8'
+      python: '3.7'
       env: TOXENV=docs_linkcheck
     # check that conda build/install works
     - os: linux
-      python: '3.8'
+      python: '3.7'
       env: TOXENV=condarecipe
     # linux, various python and notebook versions
     - os: linux
-      python: '3.8'
-      env: TOXENV=py38-notebook60
+      python: '3.7'
+      env: TOXENV=py37-notebook60
     - os: linux
-      python: '3.8'
-      env: TOXENV=py38-notebook
+      python: '3.7'
+      env: TOXENV=py37-notebook
     - os: linux
-      python: '3.8'
+      python: '3.7'
       env: TOXENV=appveyorartifacts
   allow_failures:
     - env: TOXENV=appveyorartifacts

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
-# http://travis-ci.org/#!/ipython-contrib/jupyter_contrib_nbextensions
+# http://travis-ci.org/#!/ipython-contrib/jupyter_contrib_nbextensions 
 language: python
 dist: xenial
 sudo: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,33 +18,36 @@ matrix:
   include:
     # packaging sanity check
     - os: linux
-      python: '3.7'
+      python: '3.6'
       env: TOXENV=check
     # python linting
     - os: linux
-      python: '3.7'
+      python: '3.6'
       env: TOXENV=lint
     # check docs build correctly
     - os: linux
-      python: '3.7'
+      python: '3.6'
       env: TOXENV=docs_build
     # check docs links
     - os: linux
-      python: '3.7'
+      python: '3.6'
       env: TOXENV=docs_linkcheck
     # check that conda build/install works
     - os: linux
-      python: '3.7'
+      python: '3.6'
       env: TOXENV=condarecipe
     # linux, various python and notebook versions
     - os: linux
-      python: '3.7'
-      env: TOXENV=py37-notebook60
+      python: '3.6'
+      env: TOXENV=py36-notebook55
+      - os: linux
+      python: '3.6'
+      env: TOXENV=py36-notebook60
     - os: linux
-      python: '3.7'
-      env: TOXENV=py37-notebook
+      python: '3.6'
+      env: TOXENV=py36-notebook
     - os: linux
-      python: '3.7'
+      python: '3.6'
       env: TOXENV=appveyorartifacts
   allow_failures:
     - env: TOXENV=appveyorartifacts
@@ -55,9 +58,11 @@ env:
     - LD_PRELOAD=/lib/x86_64-linux-gnu/libSegFault.so
     - SEGFAULT_SIGNALS=all
 before_install:
-  - uname -a
-  - id -un
-  - id -Gn
+  # - uname -a
+  # - id -un
+  # - id -Gn
+  - python --version
+  - pip install -U pip
   # stuff for conda recipe
   - 'if [[ ${TOXENV} == "condarecipe" ]]; then wget https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -O miniconda.sh; fi'
   - 'if [[ ${TOXENV} == "condarecipe" ]]; then bash miniconda.sh -b -p $HOME/miniconda; fi'

--- a/.travis.yml
+++ b/.travis.yml
@@ -40,7 +40,7 @@ matrix:
     - os: linux
       python: '3.6'
       env: TOXENV=py36-notebook55
-      - os: linux
+    - os: linux
       python: '3.6'
       env: TOXENV=py36-notebook60
     - os: linux
@@ -61,7 +61,6 @@ before_install:
   - uname -a
   - id -un
   - id -Gn
-  - pip install -U pip
   # stuff for conda recipe
   - 'if [[ ${TOXENV} == "condarecipe" ]]; then wget https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -O miniconda.sh; fi'
   - 'if [[ ${TOXENV} == "condarecipe" ]]; then bash miniconda.sh -b -p $HOME/miniconda; fi'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ which makes it much easier to fill in each release's changelog :)
 
 - Replace `template_path` with `template_paths` [#1532](https://github.com/ipython-contrib/jupyter_contrib_nbextensions/pull/1532). Nbconvert 6.0 replaced `template_path` with `template_paths` (see https://nbconvert.readthedocs.io/en/latest/changelog.html#significant-changes). This change in Nbconvert 6.0 causes errors in jupyter_latex_envs and in jupyter_contrib_nbextensions (see [#1529](https://github.com/ipython-contrib/jupyter_contrib_nbextensions/issues/1529).
 - Update `install_requires` list in `setup.py` with 'nbconvert >=6.0' 
+- Drop support for python < 3.6
 
 0.5.1
 -----

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,9 @@ Unreleased (aka. GitHub master)
 This is where each new PR to the project should add a summary of its changes,
 which makes it much easier to fill in each release's changelog :)
 
+- Replace `template_path` with `template_paths` [#1532](https://github.com/ipython-contrib/jupyter_contrib_nbextensions/pull/1532). Nbconvert 6.0 replaced `template_path` with `template_paths` (see https://nbconvert.readthedocs.io/en/latest/changelog.html#significant-changes). This change in Nbconvert 6.0 causes errors in jupyter_latex_envs and in jupyter_contrib_nbextensions (see [#1529](https://github.com/ipython-contrib/jupyter_contrib_nbextensions/issues/1529).
+- Update `install_requires` list in `setup.py` with 'nbconvert >=6.0' 
+
 0.5.1
 -----
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -14,29 +14,23 @@ environment:
     PIP_ONLY_BINARY: lxml
   matrix:
 
-    - TOXENV: 'py27-notebook'
-      TOXPYTHON: C:\Python27\python.exe
-      PYTHON_HOME: C:\Python27
-      PYTHON_VERSION: '2.7'
-      PYTHON_ARCH: '32'
-
-    - TOXENV: 'py36-notebook44'
+    - TOXENV: 'py36-notebook60'
       TOXPYTHON: C:\Python36\python.exe
       PYTHON_HOME: C:\Python36
       PYTHON_VERSION: '3.6'
-      PYTHON_ARCH: '32'
+      PYTHON_ARCH: '64'
 
-    - TOXENV: 'py36-notebook54'
+    - TOXENV: 'py37-notebook60'
       TOXPYTHON: C:\Python36\python.exe
-      PYTHON_HOME: C:\Python36
-      PYTHON_VERSION: '3.6'
-      PYTHON_ARCH: '32'
+      PYTHON_HOME: C:\Python37
+      PYTHON_VERSION: '3.7'
+      PYTHON_ARCH: '64'
 
-    - TOXENV: 'py36-notebook55'
-      TOXPYTHON: C:\Python36\python.exe
-      PYTHON_HOME: C:\Python36
-      PYTHON_VERSION: '3.6'
-      PYTHON_ARCH: '32'
+    - TOXENV: 'py38-notebook60'
+      TOXPYTHON: C:\Python38\python.exe
+      PYTHON_HOME: C:\Python38
+      PYTHON_VERSION: '3.8'
+      PYTHON_ARCH: '64'
 
 init:
   - ps: echo $env:TOXENV

--- a/conda.recipe/meta.yaml
+++ b/conda.recipe/meta.yaml
@@ -25,10 +25,10 @@ requirements:
     - jupyter_contrib_core >=0.3.3
     - jupyter_core
     - jupyter_highlight_selected_word >=0.1.1
-    - jupyter_latex_envs >=1.3.8
+    - jupyter_latex_envs >=1.4.0
     - jupyter_nbextensions_configurator >=0.4.0
     - nbconvert >=4.2
-    - notebook >=4.0
+    - notebook >=6.0
     - pyyaml
     - tornado
     - traitlets >=4.1

--- a/setup.py
+++ b/setup.py
@@ -6,8 +6,6 @@
 # Imports
 # -----------------------------------------------------------------------------
 
-from __future__ import print_function
-
 import os
 from glob import glob
 
@@ -65,10 +63,10 @@ if you encounter any problems, and create a new issue if needed!
             'jupyter_contrib_core >=0.3.3',
             'jupyter_core',
             'jupyter_highlight_selected_word >=0.1.1',
-            'jupyter_latex_envs >=1.3.8',
+            'jupyter_latex_envs >=1.4.0',
             'jupyter_nbextensions_configurator >=0.4.0',
             'nbconvert >=6.0',
-            'notebook >=4.0',
+            'notebook >=6.0',
             'pyyaml',
             'tornado',
             'traitlets >=4.1',

--- a/setup.py
+++ b/setup.py
@@ -40,7 +40,7 @@ The maturity of the provided extensions varies, so please check
 `the repository issues page <https://github.com/ipython-contrib/jupyter_contrib_nbextensions/issues>`_
 if you encounter any problems, and create a new issue if needed!
 """,  # noqa: E501
-        version='0.5.1',
+        version='0.5.2',
         author='ipython-contrib and jupyter-contrib developers',
         author_email='jupytercontrib@gmail.com',
         url=('https://github.com/'
@@ -79,7 +79,7 @@ if you encounter any problems, and create a new issue if needed!
                 'pip',
                 'requests',
             ],
-            'test:python_version == "3.8"': [
+            'test:python_version == "3.6"': [
                 'mock',
             ],
         },

--- a/setup.py
+++ b/setup.py
@@ -67,7 +67,7 @@ if you encounter any problems, and create a new issue if needed!
             'jupyter_highlight_selected_word >=0.1.1',
             'jupyter_latex_envs >=1.3.8',
             'jupyter_nbextensions_configurator >=0.4.0',
-            'nbconvert >=4.2',
+            'nbconvert >=6.0',
             'notebook >=4.0',
             'pyyaml',
             'tornado',
@@ -81,7 +81,7 @@ if you encounter any problems, and create a new issue if needed!
                 'pip',
                 'requests',
             ],
-            'test:python_version == "2.7"': [
+            'test:python_version == "3.8"': [
                 'mock',
             ],
         },

--- a/src/jupyter_contrib_nbextensions/application.py
+++ b/src/jupyter_contrib_nbextensions/application.py
@@ -1,8 +1,6 @@
 # -*- coding: utf-8 -*-
 """App to install/remove jupyter_contrib_nbextensions."""
 
-from __future__ import print_function, unicode_literals
-
 import copy
 import sys
 

--- a/src/jupyter_contrib_nbextensions/config_scripts/highlight_html_cfg.py
+++ b/src/jupyter_contrib_nbextensions/config_scripts/highlight_html_cfg.py
@@ -7,7 +7,7 @@ pp_mod_name = 'jupyter_contrib_nbextensions.nbconvert_support.pp_highlighter'
 
 c = get_config()  # noqa
 c.NbConvertApp.export_format = "html"
-c.Exporter.template_path = [
+c.Exporter.template_paths = [
     '.',
     jupyter_contrib_nbextensions.nbconvert_support.templates_directory(),
     os.path.join(jcnbe_dir, 'nbextensions', 'highlighter')

--- a/src/jupyter_contrib_nbextensions/config_scripts/highlight_latex_cfg.py
+++ b/src/jupyter_contrib_nbextensions/config_scripts/highlight_latex_cfg.py
@@ -7,7 +7,7 @@ pp_mod_name = 'jupyter_contrib_nbextensions.nbconvert_support.pp_highlighter'
 
 c = get_config()  # noqa
 c.NbConvertApp.export_format = "latex"
-c.Exporter.template_path = [
+c.Exporter.template_paths = [
     '.',
     jupyter_contrib_nbextensions.nbconvert_support.templates_directory(),
     os.path.join(jcnbe_dir, 'nbextensions', 'highlighter')

--- a/src/jupyter_contrib_nbextensions/install.py
+++ b/src/jupyter_contrib_nbextensions/install.py
@@ -1,10 +1,6 @@
 # -*- coding: utf-8 -*-
 """API to install/remove all jupyter_contrib_nbextensions."""
 
-from __future__ import (
-    absolute_import, division, print_function, unicode_literals,
-)
-
 import errno
 import os
 

--- a/src/jupyter_contrib_nbextensions/install.py
+++ b/src/jupyter_contrib_nbextensions/install.py
@@ -124,7 +124,7 @@ def toggle_install_config(install, user=False, sys_prefix=False,
     if logger:
         logger.info('--  Configuring nbconvert template path')
     # our templates directory
-    _update_config_list(config, 'Exporter.template_path', [
+    _update_config_list(config, 'Exporter.template_paths', [
         '.',
         jupyter_contrib_nbextensions.nbconvert_support.templates_directory(),
     ], install)

--- a/src/jupyter_contrib_nbextensions/migrate.py
+++ b/src/jupyter_contrib_nbextensions/migrate.py
@@ -128,7 +128,7 @@ def _uninstall_pre_config(logger=None):
     config = Config(cm.get(config_basename))
     if config and logger:
         logger.info('- Removing old config values from {}'.format(config_path))
-    _update_config_list(config, 'Exporter.template_path', [
+    _update_config_list(config, 'Exporter.template_paths', [
         '.', os.path.join(jupyter_data_dir(), 'templates'),
     ], False)
     _update_config_list(config, 'Exporter.preprocessors', [

--- a/src/jupyter_contrib_nbextensions/nbconvert_support/exporter_inliner.py
+++ b/src/jupyter_contrib_nbextensions/nbconvert_support/exporter_inliner.py
@@ -39,8 +39,8 @@ class ExporterInliner(HTMLExporter):
             templates_directory)
         contrib_templates_dir = templates_directory()
 
-        template_path = c.TemplateExporter.setdefault('template_path', [])
-        if contrib_templates_dir not in template_path:
-            template_path.append(contrib_templates_dir)
+        template_paths = c.TemplateExporter.setdefault('template_paths', [])
+        if contrib_templates_dir not in template_paths:
+            template_paths.append(contrib_templates_dir)
 
         return c

--- a/src/jupyter_contrib_nbextensions/nbconvert_support/toc2.py
+++ b/src/jupyter_contrib_nbextensions/nbconvert_support/toc2.py
@@ -55,7 +55,7 @@ class TocExporter(HTMLExporter):
             templates_directory)
         c.merge(super(TocExporter, self).default_config)
 
-        c.TemplateExporter.template_path = [
+        c.TemplateExporter.template_paths = [
             '.',
             templates_directory(),
         ]

--- a/src/jupyter_contrib_nbextensions/nbextensions/runtools/readme.md
+++ b/src/jupyter_contrib_nbextensions/nbextensions/runtools/readme.md
@@ -78,7 +78,7 @@ print(templates_directory())
 ```
 
 The template needs to be in a path where nbconvert can find it. This can be your local path or specified in 
-`jupyter_nbconvert_config` or `jupyter_notebook_config` as `c.Exporter.template_path`, see [Jupyter docs](https://jupyter-notebook.readthedocs.io/en/latest/config.html).
+`jupyter_nbconvert_config` or `jupyter_notebook_config` as `c.Exporter.template_paths`, see [Jupyter docs](https://jupyter-notebook.readthedocs.io/en/latest/config.html).
 
 For HTML export a template is provided as `nbextensions.tpl` in the `jupyter_contrib_nbextensions` templates directory. Alternatively you can create your own template:
 ```

--- a/tox.ini
+++ b/tox.ini
@@ -14,7 +14,8 @@ basepython =
     pypy: {env:TOXPYTHON:pypy}
     py36: {env:TOXPYTHON:python3.6}
     py37: {env:TOXPYTHON:python3.7}
-    {py38,spell}: {env:TOXPYTHON:python3.8}
+    py38: {env:TOXPYTHON:python3.8}
+    {spell}: {env:TOXPYTHON:python3.7}
     {appveyorartifacts,lint,check}: {env:TOXPYTHON:python3}
     {condarecipe}: {env:TOXPYTHON:python3}
     {clean,codecov,coveralls,report}: {env:TOXPYTHON:python3}

--- a/tox.ini
+++ b/tox.ini
@@ -6,7 +6,7 @@ envlist =
     clean,
     check,
     lint,
-    {py36,py37,py38}-notebook{60},
+    {py36,py37,py38}-notebook{55,60},
     report,
 
 [testenv]
@@ -15,7 +15,7 @@ basepython =
     py36: {env:TOXPYTHON:python3.6}
     py37: {env:TOXPYTHON:python3.7}
     py38: {env:TOXPYTHON:python3.8}
-    {spell}: {env:TOXPYTHON:python3.7}
+    {spell}: {env:TOXPYTHON:python3.6}
     {appveyorartifacts,lint,check}: {env:TOXPYTHON:python3}
     {condarecipe}: {env:TOXPYTHON:python3}
     {clean,codecov,coveralls,report}: {env:TOXPYTHON:python3}
@@ -32,6 +32,7 @@ deps =
     jupyter_latex_envs>=1.4.0
     mock
     nose
+    notebook55: https://github.com/jupyter/notebook/archive/5.5.0.zip
     notebook60: https://github.com/jupyter/notebook/archive/6.0.0.zip
     notebookmaster: https://github.com/jupyter/notebook/archive/master.zip
     notebook: notebook

--- a/tox.ini
+++ b/tox.ini
@@ -6,16 +6,15 @@ envlist =
     clean,
     check,
     lint,
-    {py27,py36}-notebook{44,54,55},
+    {py36,py37,py38}-notebook{60},
     report,
 
 [testenv]
 basepython =
     pypy: {env:TOXPYTHON:pypy}
-    py27: {env:TOXPYTHON:python2.7}
     py36: {env:TOXPYTHON:python3.6}
     py37: {env:TOXPYTHON:python3.7}
-    {spell}: {env:TOXPYTHON:python2.7}
+    {py38,spell}: {env:TOXPYTHON:python3.8}
     {appveyorartifacts,lint,check}: {env:TOXPYTHON:python3}
     {condarecipe}: {env:TOXPYTHON:python3}
     {clean,codecov,coveralls,report}: {env:TOXPYTHON:python3}
@@ -29,12 +28,10 @@ usedevelop = false
 deps =
     coverage>=4.2
     jupyter_highlight_selected_word>=0.0.5
-    jupyter_latex_envs>=1.3.4
+    jupyter_latex_envs>=1.4.0
     mock
     nose
-    notebook44: https://github.com/jupyter/notebook/archive/4.4.0.zip
-    notebook54: https://github.com/jupyter/notebook/archive/5.4.0.zip
-    notebook55: https://github.com/jupyter/notebook/archive/5.5.0.zip
+    notebook60: https://github.com/jupyter/notebook/archive/6.0.0.zip
     notebookmaster: https://github.com/jupyter/notebook/archive/master.zip
     notebook: notebook
 commands =


### PR DESCRIPTION
Nbconvert 6.0 replaced 'template_path' with 'template_paths' (see https://nbconvert.readthedocs.io/en/latest/changelog.html#significant-changes).
This change in Nbconvert causes errors in jupyter_latex_envs and in jupyter_contrib_nbextensions (see  https://github.com/ipython-contrib/jupyter_contrib_nbextensions/issues/1529).

Replacing all instances of 'template_path' with 'template_paths' in both jupyter_latex_envs and in jupyter_contrib_nbextensions fixes the error.