### PR TITLE
[toc2] fix for disappearing sidebar in static html_toc export

### DIFF
--- a/src/jupyter_contrib_nbextensions/nbextensions/toc2/toc2.js
+++ b/src/jupyter_contrib_nbextensions/nbextensions/toc2/toc2.js
@@ -311,7 +311,6 @@
 
     var makeUnmakeSidebar = function (cfg) {
         var make_sidebar = cfg.sideBar;
-        var view_rect = (liveNotebook ? document.getElementById('site') : document.body).getBoundingClientRect();
         var wrap = $('#toc-wrapper')
             .toggleClass('sidebar-wrapper', make_sidebar)
             .toggleClass('float-wrapper', !make_sidebar)
@@ -319,7 +318,8 @@
         wrap.children('.ui-resizable-se').toggleClass('ui-icon', !make_sidebar);
         wrap.children('.ui-resizable-e').toggleClass('ui-icon ui-icon-grip-dotted-vertical', make_sidebar);
         if (make_sidebar) {
-            wrap.css({top: view_rect.top, height: '', left: 0});
+            var sidebar_top = liveNotebook ? document.getElementById('site').top : 0
+            wrap.css({top: sidebar_top,height: "",left: 0});
         }
         else {
             wrap.css({height: toc_position.height});
@@ -367,7 +367,7 @@
             drag: function(event, ui) {
                 var make_sidebar = ui.position.left < 20; // 20 is snapTolerance
                 if (make_sidebar) {
-                    ui.position.top = (liveNotebook ? document.getElementById('site') : document.body).getBoundingClientRect().top;
+                    ui.position.top = liveNotebook ? document.getElementById('site').top : 0
                     ui.position.left = 0;
                 }
                 if (make_sidebar !== cfg.sideBar) {


### PR DESCRIPTION
Fix for issue i had w/ static html dumps of notebooks (w/ the toc2 sidebar) - where the table of contents sidebar would disappear (https://github.com/ipython-contrib/jupyter_contrib_nbextensions/issues/1547)

problem was that the sidebar top position was getting set to scroll position, but the css must have set it to a fixed position or something - so it should have been `0`

tested my static notebook dump in firefox and chrome  -worked in both - also tested the dynamic sidebar in chrome

someone who knows more about the repo should look over this b/c I dont know anything about webdev (or this repo)

also - linked issue: https://github.com/ipython-contrib/jupyter_contrib_nbextensions/issues/1547