### PR TITLE
varInspector: return len if object has no shape

### DIFF
--- a/src/jupyter_contrib_nbextensions/nbextensions/varInspector/var_list.py
+++ b/src/jupyter_contrib_nbextensions/nbextensions/varInspector/var_list.py
@@ -28,7 +28,10 @@ def _getshapeof(x):
     try:
         return x.shape
     except AttributeError: #x does not have a shape
-        return None
+        try:
+            return len(x)
+        except TypeError: #object of type .. has no len()
+            return None
 
 def _getcontentof(x):
     length = 150


### PR DESCRIPTION
The length of an object is an interesting property. And one could argue that the length is the shape of strings, lists, dicts and many other types.
The proposed changes will show the length of an object inside the variable inspector if the object has no shape.