### PR TITLE
toc in html export contains programmatically-generated headers

### DIFF
--- a/src/jupyter_contrib_nbextensions/nbextensions/toc2/toc2.js
+++ b/src/jupyter_contrib_nbextensions/nbextensions/toc2/toc2.js
@@ -164,9 +164,9 @@
         }
     };
 
-    //  
-    window.addEventListener('popstate', 
-        function(e) { 
+    //
+    window.addEventListener('popstate',
+        function(e) {
             if (e.state != null && e.state.back != null) {
                 var back_id = e.state.back;
                 document.getElementById(back_id).scrollIntoView(true)
@@ -586,7 +586,7 @@
         // excepting any header which contains an html tag with class 'tocSkip'
         // eg in ## title <a class='tocSkip'>,
         // or the ToC cell.
-        all_headers = $('.text_cell_render').find('[id]:header:not(:has(.tocSkip))');
+        all_headers = $('.text_cell_render,.output_html').find('[id]:header:not(:has(.tocSkip))');
         var min_lvl = 1 + Number(Boolean(cfg.skip_h1_title)),
             lbl_ary = [];
         for (; min_lvl <= 6; min_lvl++) {


### PR DESCRIPTION
proposed fix for #1594

for this to work, users have to manually assign an unique id attribute to the generated headers