### PR TITLE
Remove dependency on jupyter_latex_envs

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -63,7 +63,6 @@ if you encounter any problems, and create a new issue if needed!
             'jupyter_contrib_core >=0.3.3',
             'jupyter_core',
             'jupyter_highlight_selected_word >=0.1.1',
-            'jupyter_latex_envs >=1.4.0',
             'jupyter_nbextensions_configurator >=0.4.0',
             'nbconvert >=6.0',
             'notebook >=6.0',


### PR DESCRIPTION
Should "fix" the last "Config option template_path not recognized by LenvsLatexExporter. Did you mean one of: template_file, template_name, template_paths" warning message remaining from Issue #1532.

@jfbercher : I would remove this dependency, i.e. automatically installing your extension if you have no objections. It can be installed seperately, anyway.
