### PR TITLE
Remove the `scripts` portion of setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -99,9 +99,6 @@ if you encounter any problems, and create a new issue if needed!
                 'html_ch = jupyter_contrib_nbextensions.nbconvert_support.collapsible_headings:ExporterCollapsibleHeadings',  # noqa: E501
             ],
         },
-        scripts=[os.path.join('scripts', p) for p in [
-            'jupyter-contrib-nbextension',
-        ]],
         classifiers=[
             'Development Status :: 1 - Planning',
             'Intended Audience :: End Users/Desktop',


### PR DESCRIPTION
Scripts is deprecated by entry_points and when both exist it causes errors for some PEP-compliant installers.

Some details here: https://github.com/bazelbuild/rules_python/issues/765#issuecomment-1193000233