### PR TITLE
`limit_outputs`: do not truncate HTML outputs

### DIFF
--- a/src/jupyter_contrib_nbextensions/nbextensions/limit_output/limit-output.yaml
+++ b/src/jupyter_contrib_nbextensions/nbextensions/limit_output/limit-output.yaml
@@ -24,6 +24,10 @@ Parameters:
   description: Enable limiting display_data messages
   input_type: checkbox
   default: false
+- name: limit_html_output
+  description: Enable limiting HTML outputs
+  input_type: checkbox
+  default: false
 - name: limit_output_message
   description: Message to append when output is limited
   input_type: text

--- a/src/jupyter_contrib_nbextensions/nbextensions/limit_output/main.js
+++ b/src/jupyter_contrib_nbextensions/nbextensions/limit_output/main.js
@@ -18,6 +18,7 @@ define([
         limit_stream : true,
         limit_execute_result : true,
         limit_display_data : false,
+        limit_html_output : false,
         // message to print when output is limited
         limit_output_message : '<b>limit_output extension: Maximum message size of {limit_output_length} exceeded with {output_length} characters</b>'
     };
@@ -49,6 +50,14 @@ define([
                 return old_handle_output.apply(this, arguments);
             }
             else {
+                // HTML contents can not be simply truncated
+                // that would result unclosed tags, corrupted HTML
+                if (
+                    !params.limit_html_output &&
+                    msg.content.data['text/html'] !== undefined
+                ) {
+                    return old_handle_output.apply(this, arguments);
+                }
                 // get MAX_CHARACTERS from cell metadata if present, otherwise param
                 //msg.header.msg_type
                 var MAX_CHARACTERS = params.limit_output;


### PR DESCRIPTION
- Truncating HTML (such as pandas data frames) resulted in unclosed tags and the corrupted HTML was often illegible below the affected cells
- New Boolean parameter `limit_html_output`
- New default behaviour is to keep outputs intact if they have HTML content