### PR TITLE
Update CDN links in toc2.tpl template

### DIFF
--- a/src/jupyter_contrib_nbextensions/nbextensions/addbefore/addbefore.yaml
+++ b/src/jupyter_contrib_nbextensions/nbextensions/addbefore/addbefore.yaml
@@ -4,4 +4,4 @@ Description: This extension enables the Add Cell before button (from iPython 1)
 Link: readme.md
 Icon: icon.png
 Main: main.js
-Compatibility: 4.x
+Compatibility: 4.x, 5.x, 6.x

--- a/src/jupyter_contrib_nbextensions/nbextensions/autosavetime/autosavetime.yaml
+++ b/src/jupyter_contrib_nbextensions/nbextensions/autosavetime/autosavetime.yaml
@@ -1,5 +1,5 @@
 Type: IPython Notebook Extension
-Compatibility: 3.x, 4.x, 5.x
+Compatibility: 3.x, 4.x, 5.x, 6.x
 Name: AutoSaveTime
 Main: main.js
 Icon: icon.png

--- a/src/jupyter_contrib_nbextensions/nbextensions/autoscroll/autoscroll.yaml
+++ b/src/jupyter_contrib_nbextensions/nbextensions/autoscroll/autoscroll.yaml
@@ -1,5 +1,5 @@
 Type: IPython Notebook Extension
-Compatibility: 3.x, 4.x
+Compatibility: 3.x, 4.x, 5.x
 Name: Autoscroll
 Main: main.js
 Icon: icon.png

--- a/src/jupyter_contrib_nbextensions/nbextensions/codefolding/codefolding.yaml
+++ b/src/jupyter_contrib_nbextensions/nbextensions/codefolding/codefolding.yaml
@@ -4,7 +4,7 @@ Description: This extension enables the CodeMirror feature to allow codefolding 
 Link: readme.md
 Icon: icon.png
 Main: main.js
-Compatibility: 4.x, 5.x
+Compatibility: 4.x, 5.x, 6.x
 Parameters:
 - name: codefolding_hotkey
   description: Hotkey to fold/unfold code

--- a/src/jupyter_contrib_nbextensions/nbextensions/codemirror_mode_extensions/codemirror_mode_extensions.yaml
+++ b/src/jupyter_contrib_nbextensions/nbextensions/codemirror_mode_extensions/codemirror_mode_extensions.yaml
@@ -3,5 +3,8 @@ Name: CodeMirror mode extensions
 Description: |
   Extends some CodeMirror modes with extra features. Currently just adds
   support for comment/uncomment and folding for octave/MATLAB mode.
+
+  ** Deprecated **
+
 Main: main.js
 Compatibility: 4.x

--- a/src/jupyter_contrib_nbextensions/nbextensions/collapsible_headings/collapsible_headings.yaml
+++ b/src/jupyter_contrib_nbextensions/nbextensions/collapsible_headings/collapsible_headings.yaml
@@ -1,5 +1,5 @@
 Type: Jupyter Notebook Extension
-Compatibility: 4.x, 5.x
+Compatibility: 4.x, 5.x, 6.x
 Name: Collapsible Headings
 Main: main.js
 Description: "Allows notebook to have collapsible sections, separated by headings"

--- a/src/jupyter_contrib_nbextensions/nbextensions/comment-uncomment/comment-uncomment.yaml
+++ b/src/jupyter_contrib_nbextensions/nbextensions/comment-uncomment/comment-uncomment.yaml
@@ -1,5 +1,5 @@
 Type: IPython Notebook Extension
-Compatibility: 4.x, 5.x
+Compatibility: 4.x, 5.x, 6.x
 Name: Comment/Uncomment Hotkey
 Main: main.js
 Description: add new configurable hotkey binding to toggle comments

--- a/src/jupyter_contrib_nbextensions/nbextensions/livemdpreview/livemdpreview.yml
+++ b/src/jupyter_contrib_nbextensions/nbextensions/livemdpreview/livemdpreview.yml
@@ -1,5 +1,5 @@
 Type: Jupyter Notebook Extension
-Compatibility: 4.x, 5.x
+Compatibility: 4.x, 5.x, 6.x
 Name: Live Markdown Preview
 Main: livemdpreview.js
 Description: |

--- a/src/jupyter_contrib_nbextensions/nbextensions/move_selected_cells/README.md
+++ b/src/jupyter_contrib_nbextensions/nbextensions/move_selected_cells/README.md
@@ -5,7 +5,7 @@ Note: Alternatively, it is now possible to use the `keyboard_shortcut_editor` to
 
 Initial version for Jupyter 4.0: a bit dirty because it would be better to act on DOM elements and write a correct move_cells() function. 
 New version, updated to Jupyter 4.2+, now takes advantage of `Jupyter.notebook.move_selection_{down, up}` new functions
-
+*Deprecation warning*: Using deprecated API, might not work above notebook version 6.x.
 
 Keyboard shortcuts: *Alt-up* and *Alt-down* (works also with single cells!)
 

--- a/src/jupyter_contrib_nbextensions/nbextensions/move_selected_cells/main.js
+++ b/src/jupyter_contrib_nbextensions/nbextensions/move_selected_cells/main.js
@@ -40,7 +40,7 @@ define([
                 help_index: 'ht',
                 handler: function(event) {
                     var ncells = Jupyter.notebook.ncells();
-                    var s = Jupyter.notebook.get_selected_indices();
+                    var s = Jupyter.notebook.get_selected_cells_indices();
                     //ensure cells indices are reverse sorted
                     var ss = s.sort(function(x, y) {
                         return x - y }).reverse();
@@ -58,7 +58,7 @@ define([
                 help: 'Move selected cells up',
                 help_index: 'ht',
                 handler: function(event) {
-                    var s = Jupyter.notebook.get_selected_indices();
+                    var s = Jupyter.notebook.get_selected_cells_indices();
                     //ensure cells indices are sorted 
                     var ss = s.sort(function(x, y) {
                         return x - y });

--- a/src/jupyter_contrib_nbextensions/nbextensions/move_selected_cells/move_selected_cells.yaml
+++ b/src/jupyter_contrib_nbextensions/nbextensions/move_selected_cells/move_selected_cells.yaml
@@ -3,4 +3,4 @@ Name: Move selected cells
 Description: Move selected cell*s* using keybaord shortcuts Alt-up and Alt-down
 Link: README.md
 Main: main.js
-Compatibility: 4.x, 5.x
+Compatibility: 4.x, 5.x, 6.x

--- a/src/jupyter_contrib_nbextensions/nbextensions/navigation-hotkeys/hotkeys.yaml
+++ b/src/jupyter_contrib_nbextensions/nbextensions/navigation-hotkeys/hotkeys.yaml
@@ -4,7 +4,7 @@ Description: Additional hotkeys for easier navigation in the notebook
 Link: readme.md
 Icon: icon.png
 Main: main.js
-Compatibility: 4.x, 5.x
+Compatibility: 4.x, 5.x, 6.x
 Parameters:
 - name: toggle_enable_edit_shortcuts
   description: Enable all edit shortcuts

--- a/src/jupyter_contrib_nbextensions/nbextensions/notify/notify.yaml
+++ b/src/jupyter_contrib_nbextensions/nbextensions/notify/notify.yaml
@@ -6,7 +6,7 @@ Description: >
 Link: readme.md
 Icon: notification.png
 Main: notify.js
-Compatibility: 4.x, 5.x
+Compatibility: 4.x, 5.x, 6.x
 Parameters:
 - name: notify.sticky
   description: Require interactions on notifications to dismiss them. (Chrome only)

--- a/src/jupyter_contrib_nbextensions/nbextensions/printview/printview.yaml
+++ b/src/jupyter_contrib_nbextensions/nbextensions/printview/printview.yaml
@@ -4,7 +4,7 @@ Description: Calls nbconvert and shows the generated output in a new browser tab
 Link: readme.md
 Icon: icon.png
 Main: main.js
-Compatibility: 4.x, 5.x
+Compatibility: 4.x, 5.x, 6.x
 Parameters:
 - name: printview_nbconvert_options
   description: nbconvert options

--- a/src/jupyter_contrib_nbextensions/nbextensions/python-markdown/python-markdown.yaml
+++ b/src/jupyter_contrib_nbextensions/nbextensions/python-markdown/python-markdown.yaml
@@ -5,4 +5,4 @@ Link: readme.md
 Icon: python-markdown.png
 Main: main.js
 Preprocessor: pymdpreprocessor.py
-Compatibility: 4.x, 5.x
+Compatibility: 4.x, 5.x, 6.x

--- a/src/jupyter_contrib_nbextensions/nbextensions/qtconsole/qtconsole.yaml
+++ b/src/jupyter_contrib_nbextensions/nbextensions/qtconsole/qtconsole.yaml
@@ -3,4 +3,4 @@ Name: Launch QTConsole
 Link: README.md
 Description: Launch a QTConsole attached to the running kernel
 Main: qtconsole.js
-Compatibility: 4.x
+Compatibility: 4.x, 5.x, 6.x

--- a/src/jupyter_contrib_nbextensions/nbextensions/rubberband/rubberband.yaml
+++ b/src/jupyter_contrib_nbextensions/nbextensions/rubberband/rubberband.yaml
@@ -4,4 +4,4 @@ Description: The rubberband extension allows selecting multiple cells
 Link: readme.md
 Icon: icon.png
 Main: main.js
-Compatibility: 4.x, 5.x
+Compatibility: 4.x, 5.x, 6.x

--- a/src/jupyter_contrib_nbextensions/nbextensions/ruler/ruler.yaml
+++ b/src/jupyter_contrib_nbextensions/nbextensions/ruler/ruler.yaml
@@ -4,7 +4,7 @@ Description: This extension enables the Ruler CodeMirror feature
 Link: readme.md
 Icon: icon.png
 Main: main.js
-Compatibility: 4.x, 5.x
+Compatibility: 4.x, 5.x, 6.x
 Parameters:
 
 - name: ruler_column

--- a/src/jupyter_contrib_nbextensions/nbextensions/runtools/runtools.yaml
+++ b/src/jupyter_contrib_nbextensions/nbextensions/runtools/runtools.yaml
@@ -4,7 +4,7 @@ Description: Runtools provide a number of additional functions for working with 
 Link: readme.md
 Icon: icon.png
 Main: main.js
-Compatibility: 5.x
+Compatibility: 5.x, 6.x
 Parameters:
 - name: runtools.run_cells_above
   description: run cells above

--- a/src/jupyter_contrib_nbextensions/nbextensions/skip-traceback/skip-traceback.yaml
+++ b/src/jupyter_contrib_nbextensions/nbextensions/skip-traceback/skip-traceback.yaml
@@ -6,7 +6,7 @@ Description: |
 Link: readme.md
 Icon: icon.png
 Main: main.js
-Compatibility: 4.x
+Compatibility: 4.x, 5.x, 6.x
 Parameters:
 
   - name: skip-traceback.animation_duration

--- a/src/jupyter_contrib_nbextensions/nbextensions/toc2/main.js
+++ b/src/jupyter_contrib_nbextensions/nbextensions/toc2/main.js
@@ -28,7 +28,7 @@ define([
     // extra download as html with toc menu
     function addSaveAsWithToc() {
 
-      if (parseFloat(Jupyter.version.substr(0, 3)) >= 5.1) {
+      if (parseFloat(((typeof sys_info === 'undefined') ? Jupyter.version : sys_info.notebook_version).substr(0, 3)) >= 5.1) {
         if ($("#download_html_toc").length === 0) {
           /* Add an entry in the download menu */
           var downloadEntry = $('<li id="download_html_toc"><a href="#">HTML with toc (.html)</a></li>')
@@ -39,13 +39,13 @@ define([
         }
       }
       else {   /* Add a "save a" menu entry for pre 5.1 versions (needs python kernel) */
-        if (IPython.notebook.metadata.kernelspec.language == 'python') {
-            if ($('#save_html_with_toc').length == 0) {
+        if (IPython.notebook.metadata.kernelspec.language === 'python') {
+            if ($('#save_html_with_toc').length === 0) {
                 $('#save_checkpoint').after("<li id='save_html_with_toc'/>")
                 $('#save_html_with_toc')
                     .append($('<a/>').text('Save as HTML (with toc)').attr("href", "#"))
                     .on('click', function (evt) {
-                        if (IPython.notebook.metadata.kernelspec.language == 'python') {
+                        if (IPython.notebook.metadata.kernelspec.language === 'python') {
                             var code = "!jupyter nbconvert '" + IPython.notebook.notebook_name + "' --template toc2";
                             console.log('[toc2] running:', code);
                             IPython.notebook.kernel.execute(code);

--- a/src/jupyter_contrib_nbextensions/nbextensions/toc2/toc2.js
+++ b/src/jupyter_contrib_nbextensions/nbextensions/toc2/toc2.js
@@ -4,7 +4,7 @@
     // This means that we're probably embedded in a page, so we need to make
     // our definition with a specific module name
     return define('nbextensions/toc2/toc2', deps, callback);
-})(['jquery', 'require'], function($, requirejs) {
+})(['jquery', 'underscore', 'require', 'jqueryui'], function($, _,  requirejs) {
     "use strict";
 
     var IPython;
@@ -586,7 +586,11 @@
         // excepting any header which contains an html tag with class 'tocSkip'
         // eg in ## title <a class='tocSkip'>,
         // or the ToC cell.
-        all_headers = $('.text_cell_render').find('[id]:header:not(:has(.tocSkip))');
+        if (liveNotebook) {
+            all_headers = $('.text_cell_render').find('[id]:header:not(:has(.tocSkip))');
+        } else {
+            all_headers = $('.jp-RenderedMarkdown').find('[id]:header:not(:has(.tocSkip))');
+        }
         var min_lvl = 1 + Number(Boolean(cfg.skip_h1_title)),
             lbl_ary = [];
         for (; min_lvl <= 6; min_lvl++) {

--- a/src/jupyter_contrib_nbextensions/nbextensions/toc2/toc2.yaml
+++ b/src/jupyter_contrib_nbextensions/nbextensions/toc2/toc2.yaml
@@ -4,7 +4,7 @@ Description: The toc2 extension enables to collect all running headers and displ
 Link: README.md
 Icon: icon.png
 Main: main.js
-Compatibility: 4.x, 5.x
+Compatibility: 4.x, 5.x, 6.x
 Parameters:
 - name: toc2.number_sections
   description: Automatically number notebook's sections

--- a/src/jupyter_contrib_nbextensions/nbextensions/toggle_all_line_numbers/main.yaml
+++ b/src/jupyter_contrib_nbextensions/nbextensions/toggle_all_line_numbers/main.yaml
@@ -4,7 +4,7 @@ Description: "Add a toolbar button and hotkey to toggle all cells' line numbers 
 Icon: icon.png
 Link: readme.md
 Main: main.js
-Compatibility: 3.x, 4.x, 5.x
+Compatibility: 3.x, 4.x, 5.x, 6.x
 Parameters:
 - name: toggle_all_linenumbers_hotkey
   description: Hotkey combination to which to bind linenumber-toggling

--- a/src/jupyter_contrib_nbextensions/nbextensions/tree-filter/tree-filter.yaml
+++ b/src/jupyter_contrib_nbextensions/nbextensions/tree-filter/tree-filter.yaml
@@ -4,7 +4,7 @@ Description: An extension that allows you to filter by filename in the Jupyter n
 Link: readme.md
 Main: index.js
 Section: tree
-Compatibility: 4.x, 5.x
+Compatibility: 4.x, 5.x, 6.x
 Parameters:
 - name: filter_keyword
   input_type: string

--- a/src/jupyter_contrib_nbextensions/templates/toc2.tpl
+++ b/src/jupyter_contrib_nbextensions/templates/toc2.tpl
@@ -4,15 +4,16 @@
 {%- block header -%}
 {{ super() }}
 
- <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/jqueryui/1.12.1/jquery-ui.css">
+<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/jqueryui/1.12.1/jquery-ui.css">
 
-<script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/jqueryui/1.9.1/jquery-ui.min.js"></script>
+<script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/jquery/3.6.1/jquery.min.js"></script>
+<script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/jqueryui/1.12.1/jquery-ui.min.js"></script>
+<script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/underscore.js/1.13.6/underscore-umd-min.js"></script>
 
-<link rel="stylesheet" type="text/css" href="https://min.gitcdn.xyz/cdn/ipython-contrib/jupyter_contrib_nbextensions/master/src/jupyter_contrib_nbextensions/nbextensions/toc2/main.css">
-
+<link rel="stylesheet" type="text/css" href="https://cdn.jsdelivr.net/gh/ipython-contrib/jupyter_contrib_nbextensions/src/jupyter_contrib_nbextensions/nbextensions/toc2/main.css">
 <link rel="stylesheet" type="text/css" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/4.7.0/css/font-awesome.min.css">
 
-<script src="https://min.gitcdn.xyz/cdn/ipython-contrib/jupyter_contrib_nbextensions/master/src/jupyter_contrib_nbextensions/nbextensions/toc2/toc2.js"></script>
+<script src="https://cdn.jsdelivr.net/gh/ipython-contrib/jupyter_contrib_nbextensions/src/jupyter_contrib_nbextensions/nbextensions/toc2/toc2.js"></script>
 
 <script>
 $( document ).ready(function(){


### PR DESCRIPTION
Use `jsdelivr.net` instead of `gitcdn.xyz`, update `jquery` and `jquery-ui` versions, and add `underscore.js` dependency.