### PR TITLE
Update for notebook 7.x

### DIFF
--- a/src/jupyter_contrib_nbextensions/nbconvert_support/collapsible_headings.py
+++ b/src/jupyter_contrib_nbextensions/nbconvert_support/collapsible_headings.py
@@ -3,7 +3,10 @@
 import json
 import os
 
-from notebook.services.config import ConfigManager
+try:
+    from notebook.services.config import ConfigManager
+except ModuleNotFoundError:
+    from jupyter_server.services.config import ConfigManager
 
 from jupyter_contrib_nbextensions import __file__ as contrib_init
 

--- a/src/jupyter_contrib_nbextensions/nbconvert_support/execute_time.py
+++ b/src/jupyter_contrib_nbextensions/nbconvert_support/execute_time.py
@@ -10,8 +10,11 @@ try:
     # notebook >= 5.0.0-rc1
     import notebook._tz as nbtz
 except ImportError:
-    # notebook < 5.0.0-rc1
-    import notebook.services.contents.tz as nbtz
+    try:
+        # notebook < 5.0.0-rc1
+        import notebook.services.contents.tz as nbtz
+    except ModuleNotFoundError:
+        import jupyter_server._tz as nbtz
 
 
 class ExecuteTimePreprocessor(ExecutePreprocessor):


### PR DESCRIPTION
Fixes `ModuleNotFoundError`; some submodules of `notebook` that moved to `jupyter_server` were finally removed in `notebook` 7.x. We try importing from `notebook` and fall back on `jupyter_server` (perhaps this should be the other way around?). 