### PR TITLE
Use cdn.jsdelivr.net instead of dead min.gitcdn.xyz in toc2.tpl

### DIFF
--- a/src/jupyter_contrib_nbextensions/templates/toc2.tpl
+++ b/src/jupyter_contrib_nbextensions/templates/toc2.tpl
@@ -8,11 +8,11 @@
 
 <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/jqueryui/1.9.1/jquery-ui.min.js"></script>
 
-<link rel="stylesheet" type="text/css" href="https://min.gitcdn.xyz/cdn/ipython-contrib/jupyter_contrib_nbextensions/master/src/jupyter_contrib_nbextensions/nbextensions/toc2/main.css">
+<link rel="stylesheet" type="text/css" href="https://cdn.jsdelivr.net/gh/ipython-contrib/jupyter_contrib_nbextensions/src/jupyter_contrib_nbextensions/nbextensions/toc2/main.css">
 
 <link rel="stylesheet" type="text/css" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/4.7.0/css/font-awesome.min.css">
 
-<script src="https://min.gitcdn.xyz/cdn/ipython-contrib/jupyter_contrib_nbextensions/master/src/jupyter_contrib_nbextensions/nbextensions/toc2/toc2.js"></script>
+<script src="https://cdn.jsdelivr.net/gh/ipython-contrib/jupyter_contrib_nbextensions/src/jupyter_contrib_nbextensions/nbextensions/toc2/toc2.js"></script>
 
 <script>
 $( document ).ready(function(){


### PR DESCRIPTION
`min.gitcdn.xyz` does not serve the scripts any more.

This replaces the links with `cdn.jsdelivr.net` which should survive longer, hopefully.