### PR TITLE
Update function import for when Notebook 7 is present

### DIFF
--- a/src/jupyter_contrib_nbextensions/install.py
+++ b/src/jupyter_contrib_nbextensions/install.py
@@ -9,7 +9,10 @@ from jupyter_contrib_core.notebook_compat import nbextensions
 from jupyter_nbextensions_configurator.application import (
     EnableJupyterNbextensionsConfiguratorApp,
 )
-from notebook.notebookapp import list_running_servers
+try:
+    from notebook.notebookapp import list_running_servers
+except ModuleNotFoundError:
+    from jupyter_server.serverapp import list_runnning_servers
 from traitlets.config import Config
 from traitlets.config.manager import BaseJSONConfigManager
 


### PR DESCRIPTION
As with https://github.com/ipython-contrib/jupyter_contrib_nbextensions/pull/1649, this import statement can be updated to import from `jupyter_server` when Notebook 7 is present rather than Notebook  <= 6.