### PR TITLE
Fix Table of Contents (2) not showing top part of table

### DIFF
--- a/src/jupyter_contrib_nbextensions/nbextensions/toc2/main.css
+++ b/src/jupyter_contrib_nbextensions/nbextensions/toc2/main.css
@@ -83,6 +83,7 @@ padding-left: 20px;
   border-style: solid;
   border-width: thin;
   background-color: #fff;   /* default - alterable via nbextension-configurator */
+  top: 10em;
 }
 
 #toc-wrapper .toc {


### PR DESCRIPTION
This adds a top margin of 10em to ensure the table of contents initial section is visible and not cutoff/inaccessible.

Before:
<img width="363" alt="Screenshot showing the inaccessible portion of the table of contents generate by ToC (2)" src="https://github.com/ipython-contrib/jupyter_contrib_nbextensions/assets/833642/3168693c-64fd-4e7c-b090-cbd829a86017">

After:
<img width="402" alt="Screenshot showing the top portion of the ToC (2) with the committed change now being accessible" src="https://github.com/ipython-contrib/jupyter_contrib_nbextensions/assets/833642/d54e85be-5741-4cc9-9fc2-02cb79426f08">

This can quickly be explored by adding a Python cell with:

```python
from IPython.display import display, HTML
display(HTML("""
<style>
#toc-wrapper { 
z-index: 90; 
position: fixed !important;
display: flex;
flex-direction: column;
overflow: hidden;
padding: 10px;
border-style: solid;
border-width: thin;
background-color: #fff;
/* default - alterable via nbextension-configurator */
top: 10em;}
</style>"""))
```

Close #1651

