### PR TITLE
Fix bug on `nbconvert`: No module named 'notebook.services'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ Unreleased (aka. GitHub master)
 
 - In *Collapsible Headings*, get the notebook version from `sys_info` if possible, resolving an incompatibility with *notebook* versions 6.5.x [#1617](https://github.com/ipython-contrib/jupyter_contrib_nbextensions/pull/1617).
 - Add short execution threshold for ExecutionTime plugin. Excution time will not show on cells that executed faster than the given threshold [#1336](https://github.com/ipython-contrib/jupyter_contrib_nbextensions/pull/1336).
+- Fix bug on nbconvert: No module named 'notebook.services' when running `jupyter nbconvert --execute --allow-errors --to pdf myfile.ipynb` [#1663](https://github.com/ipython-contrib/jupyter_contrib_nbextensions/pull/1663)
 
 0.7.0
 -----

--- a/src/jupyter_contrib_nbextensions/nbconvert_support/collapsible_headings.py
+++ b/src/jupyter_contrib_nbextensions/nbconvert_support/collapsible_headings.py
@@ -3,7 +3,7 @@
 import json
 import os
 
-from notebook.services.config import ConfigManager
+from jupyter_server.services.config import ConfigManager
 
 from jupyter_contrib_nbextensions import __file__ as contrib_init
 


### PR DESCRIPTION
when running `jupyter nbconvert --execute --allow-errors --to pdf myfile.ipynb` an error occured:  
"""
  File "/home/user/.local/lib/python3.11/site-packages/jupyter_contrib_nbextensions/nbconvert_support/__init__.py", line 5, in <module>
    from .collapsible_headings import ExporterCollapsibleHeadings
  File "/home/user/.local/lib/python3.11/site-packages/jupyter_contrib_nbextensions/nbconvert_support/collapsible_headings.py", line 6, in <module>
    from notebook.services.config import ConfigManager
ModuleNotFoundError: No module named 'notebook.services' 
"""

This change updates `collapsible_headings.py` to use the correct import `from jupyter_server.services.config import ConfigManager`